### PR TITLE
Add staged Azure SRE Agent deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Monitor Demo Lab
 
-A self-contained demo of the Azure Monitor and Microsoft Sentinel stack. Everything runs from a single config file that stays out of git, so you can stand the whole thing up in your own subscription and tear it back down when you're finished.
+A self-contained demo centered on Azure Monitor, AI, and Azure SRE Agent, with optional Microsoft Sentinel scenarios. Everything runs from a single config file that stays out of git, so you can stand the whole thing up in your own subscription and tear it back down when you're finished.
 
 - One resource group: the whole lab lands in `rg-azure-monitor-lab`.
 - Two ways to deploy it: Bicep or Terraform.

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ The pre-flight checks *availability and quota*, not *live service capacity*. Tra
 
 > Optional SRE Agent evaluation. Set `stageToggles.enableStageSreAgent` to `true` before running `deploy.ps1`. Bicep deploys one Azure SRE Agent in `swedencentral`, its managed identity and RBAC, and Azure Monitor, Application Insights, and Log Analytics connectors. New eligible customers can use a 30-day waiver of the fixed always-on charge while active Azure Agent Unit usage remains billable. Follow [Stage SRE Agent](docs/STAGE-SRE-AGENT.md) to add the Review-mode response plans and run scenarios 54 through 58.
 
-> SRE Agent is disabled by default and creates no SRE resources or SRE-related role assignments when disabled. Native provisioning is available only through the Bicep path; the Terraform path requires manual agent creation.
+> SRE Agent is disabled by default and creates no SRE resources or SRE-related role assignments when disabled. The one-shot and portal paths use `infra/main.bicep`; strict Bicep staging and Terraform use the dedicated `infra/stages/60-sre-agent` template. Terraform orchestrates that compiled Bicep stage through AzAPI.
 
 ### Option 3: Staged workshop (progressive deployment)
 
-Use the staged approach when you want to pause between capabilities, walk through the lab with an audience, or deploy only the stages needed for a particular demo. Stages A to E can be toggled in `lab.config.json`, and the optional AI stage can be enabled separately after Stage A.
+Use the staged approach when you want to pause between capabilities, walk through the lab with an audience, or deploy only the stages needed for a particular demo. Stages A to E can be toggled in `lab.config.json`. The optional AI and SRE Agent stages can be enabled separately after Stage A. Bicep deploys SRE Agent with `infra/stages/60-sre-agent.bicep`; Terraform deploys the compiled stage when `enable_stage_sre_agent = true`.
 
 Step-by-step guides:
 

--- a/docs/CUSTOMER-STAGE-HANDOUT.md
+++ b/docs/CUSTOMER-STAGE-HANDOUT.md
@@ -4,7 +4,7 @@ This one-pager helps customers decide how far to go in a workshop or pilot.
 
 ## Assumptions
 
-- Region: North Europe (App Service pins to West Europe; optional AI stage + Health Model pin to Sweden Central)
+- Region: North Europe (App Service pins to West Europe; optional AI, SRE Agent, and Health Model resources pin to Sweden Central)
 - Pricing basis: list price guidance from this lab's README
 - Cost values are directional ranges, not quotes
 - Monthly impact assumes resources are left running 24/7
@@ -20,6 +20,7 @@ This one-pager helps customers decide how far to go in a workshop or pilot.
 | Stage D - Security posture | Monitor-native detections for drift, IAM changes, exfil signals (scenarios 27, 47, 48, 49) | 5-12 min | EUR 0-15 | AzureActivity ingestion and scheduled query alerts |
 | Stage E - Optional advanced add-ons | Sentinel/reliability/archival extras (scenarios 43, 44, 45, 46) | 10-20 min | EUR 0-40 | Sentinel analytics usage, archive/restore/search workloads, preview feature telemetry |
 | Stage AI - Optional GenAI workload | Microsoft Foundry account + models (chat/embed/optimize/router), token alerts, AI FinOps observability | 5-10 min + traffic | EUR 5-30 | Per-token model usage while the traffic simulator runs (small at capacity 10; stop it to zero it out); minimal idle cost |
+| Stage SRE Agent - Optional incident investigation | Azure SRE Agent investigation and Review-mode response workflows (scenarios 54-58) | 5-10 min + portal setup | Variable; check current SRE Agent pricing | Active Agent Unit usage during an eligible 30-day always-on charge waiver; fixed always-on and usage charges after the waiver |
 
 ## Cumulative monthly range by stop point
 
@@ -31,6 +32,7 @@ This one-pager helps customers decide how far to go in a workshop or pilot.
 | Stage D | EUR 105-195 |
 | Stage E | EUR 105-235 |
 | Stage AI (add-on) | + EUR 5-30 while traffic runs |
+| Stage SRE Agent (add-on) | Variable usage during an eligible 30-day waiver; fixed always-on plus usage pricing afterward |
 
 ## Practical guidance for customer conversations
 
@@ -39,9 +41,11 @@ This one-pager helps customers decide how far to go in a workshop or pilot.
 3. Add Stage D for security posture outcomes without requiring SIEM.
 4. Add Stage E only when customer explicitly wants Sentinel/reliability-preview and accepts extra complexity.
 5. Add Stage AI when the customer wants a GenAI/FinOps observability story (token/cost telemetry, model-router, token-spike alerts). It is independent of Stages B-E and only needs Stage A.
+6. Add Stage SRE Agent when the customer wants AI-assisted incident investigation and Review-mode response plans. It depends only on Stage A, is hard pinned to Sweden Central, and remains off by default because usage is billable.
 
 ## Cost optimization notes
 
 1. Stop AKS and deallocate VMs outside workshop windows.
 2. Keep LAW caps and table plans under review.
 3. Use staged rollout so customers only pay for scenarios they are currently validating.
+4. Delete the SRE Agent before day 31 when the evaluation will not continue; stopping it does not stop the fixed always-on charge after the waiver.

--- a/docs/DEPLOY-BICEP-STEP-BY-STEP.md
+++ b/docs/DEPLOY-BICEP-STEP-BY-STEP.md
@@ -31,6 +31,7 @@ For workshop planning and customer expectation-setting, use:
 - [STAGE-D-SECURITY-POSTURE.md](STAGE-D-SECURITY-POSTURE.md)
 - [STAGE-E-OPTIONAL-ADVANCED.md](STAGE-E-OPTIONAL-ADVANCED.md)
 - [STAGE-AI.md](STAGE-AI.md)
+- [STAGE-SRE-AGENT.md](STAGE-SRE-AGENT.md)
 
 ## 3) Stage model (recommended)
 
@@ -42,6 +43,7 @@ Deploy in this order.
 4. Stage D - Security posture scenarios
 5. Stage E - Optional advanced/security add-ons
 6. Stage AI - Optional Microsoft Foundry GenAI workload (off by default)
+7. Stage SRE Agent - Optional Azure SRE Agent evaluation (off by default)
 
 ## 4) Stage details (scenarios + deployed services)
 
@@ -55,6 +57,7 @@ Use this as the workshop script: each stage adds a bounded set of capabilities a
 | Stage D - Security posture (Azure Monitor native) | Build non-SIEM security posture detections directly in Azure Monitor. | 27, 47, 48, 49 | Log Analytics RBAC model (workspace/table/row scope), AzureActivity routing prerequisite, scheduled query alerts for control-plane drift, role assignment changes, and exfil early-warning correlation, alert routing via existing Action Group. |
 | Stage E - Optional advanced/security add-ons | Layer advanced SOC and reliability preview capabilities. | 43, 44, 45, 46 | Optional Sentinel onboarding + analytics rule, search job/restore script workflow enablement, health model resources, SLI identity prerequisites and helper scripts, optional service-group/SLI setup flow. |
 | Stage AI - Optional GenAI workload | Add a Microsoft Foundry workload emitting token/trace/cost telemetry, with AI FinOps observability. Off by default (billable models, region-limited). | - | Foundry (AI Services) account + project pinned to swedencentral, four model deployments (gpt-5-mini, text-embedding-3-small, gpt-5.4, model-router), App Insights connection, token anomaly + spike metric alerts, AI FinOps query pack + workbook, and an AI tier folded into the workload health model. Agents + traffic via scripts/setup-ai.ps1. |
+| Stage SRE Agent - Optional incident investigation | Add Azure SRE Agent investigation and Review-mode response workflows. Off by default (preview and billable). | 54, 55, 56, 57, 58 | Azure SRE Agent hard pinned to swedencentral, system-assigned and user-assigned managed identities, Azure Monitor, Application Insights, and Log Analytics connectors, resource-group reader roles, and subscription-scope Monitoring Contributor. |
 
 ### Stage dependency chain
 
@@ -64,6 +67,7 @@ Use this as the workshop script: each stage adds a bounded set of capabilities a
 4. Stage D depends on Stage A ingestion and Stage C action routing.
 5. Stage E depends on prior stages, especially LAW and monitoring identities.
 6. Stage AI depends only on Stage A (it connects to `appi-amlab`); deploy it any time after Stage A.
+7. Stage SRE Agent depends only on Stage A (Application Insights and central LAW); deploy it any time after Stage A.
 
 ### Stage acceptance criteria (high level)
 
@@ -73,6 +77,7 @@ Use this as the workshop script: each stage adds a bounded set of capabilities a
 4. Stage D done: scenario 47/48/49 queries return data and alert rules evaluate.
 5. Stage E done: optional feature endpoints/blades become accessible and testable.
 6. Stage AI done: Foundry model deployments exist, App Insights receives AI telemetry, and the AI FinOps queries return data after `setup-ai.ps1` runs.
+7. Stage SRE Agent done: the agent is in `swedencentral`, all three connectors are configured, and identity-specific RBAC validation passes.
 
 ## 5) Practical deployment commands (stage-by-stage)
 
@@ -170,7 +175,7 @@ az deployment group create -g $rg --name stage-ai-foundry --template-file infra/
 
 Stage AI depends only on Stage A and can be deployed before or after Stages B to E. If you are using the central config workflow, set `stageToggles.enableStageAI` to `true` in `lab.config.json`, run `./scripts/sync-config.ps1`, and deploy the generated parameters with the same Stage AI template. The stage is off by default because the model deployments are billable.
 
-### SRE Agent trial deployment (optional)
+### Stage SRE Agent deploy (optional)
 
 This stage depends on Stage A. Set `stageToggles.enableStageSreAgent` to `true` in `lab.config.json`, then deploy the dedicated stage template:
 

--- a/docs/DEPLOY-BICEP-STEP-BY-STEP.md
+++ b/docs/DEPLOY-BICEP-STEP-BY-STEP.md
@@ -172,13 +172,19 @@ Stage AI depends only on Stage A and can be deployed before or after Stages B to
 
 ### SRE Agent trial deployment (optional)
 
-Set `stageToggles.enableStageSreAgent` to `true` in `lab.config.json`, then run the normal staged post-deployment command:
+This stage depends on Stage A. Set `stageToggles.enableStageSreAgent` to `true` in `lab.config.json`, then deploy the dedicated stage template:
+
+```powershell
+az deployment group create -g $rg --name stage-sre-agent --template-file infra/stages/60-sre-agent.bicep --parameters namePrefix=amlab
+```
+
+The template creates the agent in `swedencentral`, its identities and RBAC, and the Azure Monitor, Application Insights, and Log Analytics connectors. Then run the normal staged post-deployment command to validate the agent and print its portal URL:
 
 ```powershell
 ./scripts/post-staged-deploy.ps1 -ResourceGroup $rg
 ```
 
-For the one-shot Bicep path, the toggle emits `enableSreAgent=true`. Bicep creates the agent in `swedencentral`, its identity and RBAC, and the Azure Monitor connectors. `setup-sre-agent.ps1` verifies the deployment afterward. Follow [STAGE-SRE-AGENT.md](STAGE-SRE-AGENT.md) to add the custom investigators and response plans.
+For the one-shot Bicep path, the toggle emits `enableSreAgent=true` and `main.bicep` creates the same resources. Follow [STAGE-SRE-AGENT.md](STAGE-SRE-AGENT.md) to add the custom investigators and response plans.
 
 ## 6) Recommended repo evolution for clean staging
 
@@ -188,6 +194,8 @@ For a cleaner customer story, split orchestration into:
 - infra/stages/20-alerting.bicep
 - infra/stages/30-security-posture.bicep
 - infra/stages/40-optional-advanced.bicep
+- infra/stages/50-ai.bicep
+- infra/stages/60-sre-agent.bicep
 
 Each stage should accept prior-stage outputs as parameters and be deployable idempotently.
 

--- a/docs/DEPLOY-TERRAFORM-STEP-BY-STEP.md
+++ b/docs/DEPLOY-TERRAFORM-STEP-BY-STEP.md
@@ -76,6 +76,7 @@ Use this matrix in customer sessions so Terraform users see exactly what each ap
 4. Stage D: scenarios 47/48/49 query outputs are non-empty and alert rules evaluate.
 5. Stage E: optional Sentinel/health/SLI capabilities are reachable and testable.
 6. Stage AI: Foundry model deployments exist, App Insights receives AI telemetry, and the AI FinOps queries return data after `setup-ai.ps1` runs.
+7. Stage SRE Agent: the agent is in `swedencentral`, all three connectors are configured, and identity-specific RBAC validation passes.
 
 ## 5) Terraform scaffold (orchestrating staged ARM/Bicep)
 
@@ -89,6 +90,7 @@ This repo ships a working staged Terraform scaffold at `terraform/` and pre-comp
 | `enable_stage_d` | `infra/stages/30-security-posture.json` |
 | `enable_stage_e` | `infra/stages/40-optional-advanced.json` |
 | `enable_stage_ai` | `infra/stages/50-ai.json` |
+| `enable_stage_sre_agent` | `infra/stages/60-sre-agent.json` |
 
 Each toggle gates its own `azapi_resource "Microsoft.Resources/deployments@2022-09-01"` block, so flipping a flag truly adds or removes only that stage's deployment.
 
@@ -110,6 +112,7 @@ az bicep build --file infra/stages/20-alerting.bicep          --outfile infra/st
 az bicep build --file infra/stages/30-security-posture.bicep  --outfile infra/stages/30-security-posture.json
 az bicep build --file infra/stages/40-optional-advanced.bicep --outfile infra/stages/40-optional-advanced.json
 az bicep build --file infra/stages/50-ai.bicep               --outfile infra/stages/50-ai.json
+az bicep build --file infra/stages/60-sre-agent.bicep        --outfile infra/stages/60-sre-agent.json
 ```
 
 The legacy `infra/main.bicep` continues to work unchanged for the original Bicep-only deployment path.
@@ -121,8 +124,8 @@ The legacy `infra/main.bicep` continues to work unchanged for the original Bicep
 The shipped files already contain the staged wiring described above. Open them and confirm:
 
 - `terraform/providers.tf` declares `azurerm ~> 4.0` and `azapi ~> 2.0` and threads `subscription_id` through both providers.
-- `terraform/variables.tf` declares the five stage toggles plus shared inputs (`subscription_id`, `resource_group_name` (default `rg-azure-monitor-lab`), `location`, `alert_email`, `vm_admin_password`, etc.).
-- `terraform/main.tf` declares one `data "azurerm_resource_group"` (BYO RG, looked up by name) plus five `azapi_resource` deployments, each guarded by its own stage toggle.
+- `terraform/variables.tf` declares seven stage toggles plus shared inputs (`subscription_id`, `resource_group_name` (default `rg-azure-monitor-lab`), `location`, `alert_email`, `vm_admin_password`, etc.).
+- `terraform/main.tf` declares one `data "azurerm_resource_group"` (BYO RG, looked up by name) plus seven `azapi_resource` deployments, each guarded by its own stage toggle.
 
 ### Step 2 - Set inputs in `terraform/stages.tfvars`
 
@@ -134,7 +137,7 @@ notepad lab.config.json   # fill in subscriptionId, tenantId, alertEmail, vmAdmi
 ./scripts/sync-config.ps1 # regenerates terraform/stages.tfvars + .azure-target.json + infra/main.parameters.json
 ```
 
-`scripts/sync-config.ps1` writes `terraform/stages.tfvars` from your central config, including the five stage toggles. Re-run it any time you change `lab.config.json` (e.g. to flip the next stage).
+`scripts/sync-config.ps1` writes `terraform/stages.tfvars` from your central config, including all seven stage toggles. Re-run it any time you change `lab.config.json` (e.g. to flip the next stage).
 
 **Or hand-edit `terraform/stages.tfvars` directly** (skip `sync-config.ps1`; the file is gitignored):
 
@@ -224,9 +227,25 @@ The AI stage creates the Foundry account, project, four model deployments, App I
 
 ### Optional SRE Agent stage
 
-The repository's Terraform path does not define `Microsoft.App/agents`; the `enableStageSreAgent` toggle applies only to the one-shot Bicep path. Use `scripts/deploy.ps1` for native SRE Agent deployment, or create an equivalent agent in `swedencentral` manually after Terraform deployment.
+Terraform deploys the compiled Stage 60 Bicep template through AzAPI. The stage depends on Stage A, remains off by default, and hard pins the SRE Agent to `swedencentral`. Enable it in `stages.tfvars`:
 
-After manually creating the agent for a Terraform-based lab, run:
+```hcl
+enable_stage_sre_agent = true
+```
+
+The deploying identity needs Owner or User Access Administrator at subscription scope because Stage 60 grants the agent connector identity Monitoring Contributor. Review the plan, apply it, and validate the deployed agent:
+
+```powershell
+terraform plan -var-file stages.tfvars
+terraform apply -var-file stages.tfvars
+./scripts/setup-sre-agent.ps1 -SubscriptionId $sub -ResourceGroup $rg
+```
+
+The stage creates the preview `Microsoft.App/agents` resource, managed identities, Azure Monitor, Application Insights, and Log Analytics connectors, and required RBAC. Active usage is billable and always-on billing can begin after an eligible trial.
+
+> Setting `enable_stage_sre_agent = false` or running `terraform destroy` removes the ARM deployment record but does not delete resources created by that nested deployment. Run `./scripts/teardown.ps1 -ResourceGroup $rg` or delete the SRE Agent explicitly before the trial ends to stop billing.
+
+For a full staged lab where Stages A and B are already complete, the normal post-deployment command also runs SRE Agent validation when `enableStageSreAgent` is true in `lab.config.json`:
 
 ```powershell
 ./scripts/post-staged-deploy.ps1 -ResourceGroup $rg
@@ -278,7 +297,7 @@ For each stage:
 
 ## 10) Tearing down the lab
 
-The resource group is BYO (Terraform does not own it via data source), so `terraform destroy` alone will not cascade-delete the LAWs, VMs, AKS, alerts, etc. — it only removes the five staged deployment records. Use Option A.
+The resource group is BYO (Terraform does not own it via data source), so `terraform destroy` alone will not cascade-delete the LAWs, VMs, AKS, alerts, etc. - it only removes the seven staged deployment records. Use Option A.
 
 ### Option A - run the teardown wrapper (recommended)
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -270,8 +270,9 @@ azure-monitor-demo-lab/
 │   │   ├─ 20-alerting.bicep        ← Action Group · alerts · AMBA · processing rules
 │   │   ├─ 30-security-posture.bicep← Sentinel · security alerts · LAW RBAC
 │   │   ├─ 40-optional-advanced.bicep ← Connection Monitor · flow logs · data export · etc.
-│   │   └─ 50-ai.bicep              ← (optional) Foundry GenAI workload · token alerts · AI FinOps observability
-│   └─ modules/                     ← 40+ reusable Bicep modules (incl. the optional AI stage)
+│   │   ├─ 50-ai.bicep              ← (optional) Foundry GenAI workload · token alerts · AI FinOps observability
+│   │   └─ 60-sre-agent.bicep       ← (optional) SRE Agent · connectors · identity and RBAC
+│   └─ modules/                     ← 40+ reusable Bicep modules (including optional AI and SRE stages)
 │       ├─ law.bicep · appinsights.bicep · azure-monitor-workspace.bicep
 │       ├─ network.bicep · vm-linux.bicep · vm-windows.bicep · vmss.bicep · aks.bicep
 │       ├─ grafana.bicep · appservice.bicep · availability-test.bicep

--- a/docs/STAGE-SRE-AGENT.md
+++ b/docs/STAGE-SRE-AGENT.md
@@ -52,6 +52,18 @@ For a one-shot deployment, `deploy.ps1` maps this toggle to the Bicep `enableSre
 - SRE Agent Administrator access for the deploying user and agent identity
 - Azure Monitor, Application Insights, and Log Analytics connectors
 
+For a strict staged Bicep deployment, deploy Stage A first and then deploy the dedicated SRE Agent stage:
+
+```powershell
+az deployment group create `
+  -g <resource-group> `
+  --name stage-sre-agent `
+  --template-file infra/stages/60-sre-agent.bicep `
+  --parameters namePrefix=amlab
+```
+
+The staged template deploys the same agent, connectors, identities, and role assignments as the one-shot path.
+
 The agent uses Review mode, Low access, the Microsoft Foundry automatic model, and a 1,000 monthly Agent Unit limit. Creating the resource can start billing. Eligible new customers receive the 30-day always-on charge waiver automatically; confirm the evaluation status in **Settings > Agent consumption** after deployment.
 
 The agent remains in `swedencentral` even when the lab and its observability resources are deployed elsewhere. This creates an intentional cross-region query and reliability dependency. Treat this lab topology as an evaluation design, not a production colocation recommendation.

--- a/infra/stages/60-sre-agent.bicep
+++ b/infra/stages/60-sre-agent.bicep
@@ -1,0 +1,61 @@
+// =====================================================================================
+// Stage SRE Agent (optional) - Azure SRE Agent and Azure Monitor connectors.
+//
+// Depends on Stage A for Application Insights and the central Log Analytics workspace.
+// The agent and its managed identity are hard pinned to swedencentral by the shared module.
+// =====================================================================================
+targetScope = 'resourceGroup'
+
+@description('Short prefix used to build resource names.')
+@minLength(3)
+@maxLength(8)
+param namePrefix string = 'amlab'
+
+@description('Tag every resource with this owner.')
+param ownerTag string = 'demo-lab'
+
+var suffix = uniqueString(resourceGroup().id)
+var appInsightsName = 'appi-${namePrefix}'
+var centralLawName = 'law-${namePrefix}-central-${take(suffix, 5)}'
+var sreAgentName = 'sre-${namePrefix}-${take(suffix, 5)}'
+
+var commonTags = {
+  owner: ownerTag
+  purpose: 'azure-monitor-demo-lab'
+  costCenter: 'demo'
+}
+
+// Created by Stage A.
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: appInsightsName
+}
+
+// Created by Stage A.
+resource centralLaw 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: centralLawName
+}
+
+module sreAgent '../modules/sre-agent.bicep' = {
+  name: 'sre-agent'
+  params: {
+    name: sreAgentName
+    appInsightsId: appInsights.id
+    appInsightsAppId: appInsights.properties.ApplicationId
+    appInsightsConnectionString: appInsights.properties.ConnectionString
+    logAnalyticsId: centralLaw.id
+    managedResourceGroupId: resourceGroup().id
+    tags: commonTags
+  }
+}
+
+module sreAgentSubscriptionRbac '../modules/sre-agent-subscription-rbac.bicep' = {
+  name: 'sre-agent-subscription-rbac'
+  scope: subscription()
+  params: {
+    principalId: sreAgent.outputs.systemPrincipalId
+  }
+}
+
+output sreAgentName string = sreAgent.outputs.name
+output sreAgentEndpoint string = sreAgent.outputs.endpoint
+output sreAgentPortalUrl string = sreAgent.outputs.portalUrl

--- a/infra/stages/60-sre-agent.json
+++ b/infra/stages/60-sre-agent.json
@@ -1,0 +1,454 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "4729222605744693011"
+    }
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "amlab",
+      "minLength": 3,
+      "maxLength": 8,
+      "metadata": {
+        "description": "Short prefix used to build resource names."
+      }
+    },
+    "ownerTag": {
+      "type": "string",
+      "defaultValue": "demo-lab",
+      "metadata": {
+        "description": "Tag every resource with this owner."
+      }
+    }
+  },
+  "variables": {
+    "suffix": "[uniqueString(resourceGroup().id)]",
+    "appInsightsName": "[format('appi-{0}', parameters('namePrefix'))]",
+    "centralLawName": "[format('law-{0}-central-{1}', parameters('namePrefix'), take(variables('suffix'), 5))]",
+    "sreAgentName": "[format('sre-{0}-{1}', parameters('namePrefix'), take(variables('suffix'), 5))]",
+    "commonTags": {
+      "owner": "[parameters('ownerTag')]",
+      "purpose": "azure-monitor-demo-lab",
+      "costCenter": "demo"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "sre-agent",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[variables('sreAgentName')]"
+          },
+          "appInsightsId": {
+            "value": "[resourceId('Microsoft.Insights/components', variables('appInsightsName'))]"
+          },
+          "appInsightsAppId": {
+            "value": "[reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').ApplicationId]"
+          },
+          "appInsightsConnectionString": {
+            "value": "[reference(resourceId('Microsoft.Insights/components', variables('appInsightsName')), '2020-02-02').ConnectionString]"
+          },
+          "logAnalyticsId": {
+            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('centralLawName'))]"
+          },
+          "managedResourceGroupId": {
+            "value": "[resourceGroup().id]"
+          },
+          "tags": {
+            "value": "[variables('commonTags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.37.4.10188",
+              "templateHash": "677787519081786153"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "SRE Agent resource name."
+              }
+            },
+            "appInsightsId": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Insights resource ID used by the agent connector and telemetry."
+              }
+            },
+            "appInsightsAppId": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Insights application ID."
+              }
+            },
+            "appInsightsConnectionString": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Application Insights connection string."
+              }
+            },
+            "logAnalyticsId": {
+              "type": "string",
+              "metadata": {
+                "description": "Log Analytics workspace resource ID used by the agent connector."
+              }
+            },
+            "managedResourceGroupId": {
+              "type": "string",
+              "metadata": {
+                "description": "Resource group ID the agent can investigate."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Resource tags."
+              }
+            }
+          },
+          "variables": {
+            "location": "swedencentral"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2024-11-30",
+              "name": "[format('id-{0}', parameters('name'))]",
+              "location": "[variables('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "isolationScope": "Regional"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(parameters('managedResourceGroupId'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '2024-11-30').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(parameters('managedResourceGroupId'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '2024-11-30').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(parameters('managedResourceGroupId'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '73c42c96-874c-492b-b04d-ab87d138a893')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '2024-11-30').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.App/agents",
+              "apiVersion": "2025-05-01-preview",
+              "name": "[parameters('name')]",
+              "location": "[variables('location')]",
+              "tags": "[union(parameters('tags'), createObject('hidden-link: /app-insights-resource-id', parameters('appInsightsId')))]",
+              "identity": {
+                "type": "SystemAssigned, UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))))]": {}
+                }
+              },
+              "properties": {
+                "knowledgeGraphConfiguration": {
+                  "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]",
+                  "managedResources": [
+                    "[parameters('managedResourceGroupId')]"
+                  ]
+                },
+                "actionConfiguration": {
+                  "accessLevel": "Low",
+                  "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]",
+                  "mode": "Review"
+                },
+                "logConfiguration": {
+                  "applicationInsightsConfiguration": {
+                    "appId": "[parameters('appInsightsAppId')]",
+                    "connectionString": "[parameters('appInsightsConnectionString')]"
+                  }
+                },
+                "upgradeChannel": "Preview",
+                "monthlyAgentUnitLimit": 1000,
+                "defaultModel": {
+                  "provider": "MicrosoftFoundry",
+                  "name": "Automatic"
+                },
+                "experimentalSettings": {
+                  "EnableWorkspaceTools": true
+                },
+                "incidentManagementConfiguration": {
+                  "type": "AzMonitor",
+                  "connectionName": "azmonitor"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]",
+                "[resourceId('Microsoft.Authorization/roleAssignments', guid(parameters('managedResourceGroupId'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '73c42c96-874c-492b-b04d-ab87d138a893'))]",
+                "[resourceId('Microsoft.Authorization/roleAssignments', guid(parameters('managedResourceGroupId'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '43d0d8ad-25c7-4714-9337-8ba259a9fe05'))]",
+                "[resourceId('Microsoft.Authorization/roleAssignments', guid(parameters('managedResourceGroupId'), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), 'acdd72a7-3385-48ef-bd42-f606fba81ae7'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(parameters('managedResourceGroupId'), resourceId('Microsoft.App/agents', parameters('name')), 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                "principalId": "[reference(resourceId('Microsoft.App/agents', parameters('name')), '2025-05-01-preview', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(parameters('managedResourceGroupId'), resourceId('Microsoft.App/agents', parameters('name')), '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                "principalId": "[reference(resourceId('Microsoft.App/agents', parameters('name')), '2025-05-01-preview', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(parameters('managedResourceGroupId'), resourceId('Microsoft.App/agents', parameters('name')), '73c42c96-874c-492b-b04d-ab87d138a893')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                "principalId": "[reference(resourceId('Microsoft.App/agents', parameters('name')), '2025-05-01-preview', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.App/agents/{0}', parameters('name'))]",
+              "name": "[guid(resourceId('Microsoft.App/agents', parameters('name')), deployer().objectId, 'e79298df-d852-4c6d-84f9-5d13249d1e55')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e79298df-d852-4c6d-84f9-5d13249d1e55')]",
+                "principalId": "[deployer().objectId]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.App/agents/{0}', parameters('name'))]",
+              "name": "[guid(resourceId('Microsoft.App/agents', parameters('name')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), 'e79298df-d852-4c6d-84f9-5d13249d1e55')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e79298df-d852-4c6d-84f9-5d13249d1e55')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '2024-11-30').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name')))]"
+              ]
+            },
+            {
+              "type": "Microsoft.App/agents/connectors",
+              "apiVersion": "2025-05-01-preview",
+              "name": "[format('{0}/{1}', parameters('name'), 'app-insights')]",
+              "properties": {
+                "dataConnectorType": "AppInsights",
+                "dataSource": "[parameters('appInsightsId')]",
+                "extendedProperties": {
+                  "armResourceId": "[parameters('appInsightsId')]",
+                  "resource": {
+                    "name": "[last(split(parameters('appInsightsId'), '/'))]"
+                  },
+                  "appId": "[parameters('appInsightsAppId')]"
+                },
+                "identity": "system"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.App/agents/connectors",
+              "apiVersion": "2025-05-01-preview",
+              "name": "[format('{0}/{1}', parameters('name'), 'log-analytics')]",
+              "properties": {
+                "dataConnectorType": "LogAnalytics",
+                "dataSource": "[parameters('logAnalyticsId')]",
+                "extendedProperties": {
+                  "armResourceId": "[parameters('logAnalyticsId')]",
+                  "resource": {
+                    "name": "[last(split(parameters('logAnalyticsId'), '/'))]"
+                  }
+                },
+                "identity": "system"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]",
+                "[resourceId('Microsoft.App/agents/connectors', parameters('name'), 'app-insights')]"
+              ]
+            },
+            {
+              "type": "Microsoft.App/agents/connectors",
+              "apiVersion": "2025-05-01-preview",
+              "name": "[format('{0}/{1}', parameters('name'), 'azure-monitor')]",
+              "properties": {
+                "dataConnectorType": "AzureMonitor",
+                "dataSource": "[subscription().id]",
+                "extendedProperties": {
+                  "armResourceId": "[subscription().id]",
+                  "lookbackDays": 7
+                },
+                "identity": "system"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.App/agents', parameters('name'))]",
+                "[resourceId('Microsoft.App/agents/connectors', parameters('name'), 'log-analytics')]"
+              ]
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "value": "[parameters('name')]"
+            },
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.App/agents', parameters('name'))]"
+            },
+            "principalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('id-{0}', parameters('name'))), '2024-11-30').principalId]"
+            },
+            "systemPrincipalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.App/agents', parameters('name')), '2025-05-01-preview', 'full').identity.principalId]"
+            },
+            "endpoint": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.App/agents', parameters('name')), '2025-05-01-preview').agentEndpoint]"
+            },
+            "portalUrl": {
+              "type": "string",
+              "value": "[format('https://sre.azure.com/#/agent/{0}/{1}/{2}', subscription().subscriptionId, resourceGroup().name, parameters('name'))]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "sre-agent-subscription-rbac",
+      "subscriptionId": "[subscription().subscriptionId]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "principalId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sre-agent'), '2022-09-01').outputs.systemPrincipalId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.37.4.10188",
+              "templateHash": "3894281302565352484"
+            }
+          },
+          "parameters": {
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "System-assigned principal ID of the Azure SRE Agent connector identity."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().id, parameters('principalId'), '43bfe7e3-6883-4a1e-b686-33a7fe5db0c7')]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43bfe7e3-6883-4a1e-b686-33a7fe5db0c7')]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'sre-agent')]"
+      ]
+    }
+  ],
+  "outputs": {
+    "sreAgentName": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sre-agent'), '2022-09-01').outputs.name.value]"
+    },
+    "sreAgentEndpoint": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sre-agent'), '2022-09-01').outputs.endpoint.value]"
+    },
+    "sreAgentPortalUrl": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'sre-agent'), '2022-09-01').outputs.portalUrl.value]"
+    }
+  }
+}

--- a/scripts/sync-config.ps1
+++ b/scripts/sync-config.ps1
@@ -174,6 +174,7 @@ $tfLines = @(
   "enable_stage_d = $((($stages.enableStageD -as [bool]).ToString()).ToLower())"
   "enable_stage_e = $((($stages.enableStageE -as [bool]).ToString()).ToLower())"
   "enable_stage_ai = $($enableStageAI.ToString().ToLower())"
+  "enable_stage_sre_agent = $($enableStageSreAgent.ToString().ToLower())"
 )
 Set-Content -Path $tfVarsPath -Value ($tfLines -join "`r`n") -Encoding UTF8
 Write-Done "OK"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -173,3 +173,26 @@ resource "azapi_resource" "stage_ai" {
     }
   }
 }
+
+# Optional SRE Agent stage: Azure SRE Agent, managed identities, Azure Monitor,
+# Application Insights and Log Analytics connectors, and required RBAC. The shared
+# Bicep module hard pins the agent to swedencentral. It references Stage A resources.
+resource "azapi_resource" "stage_sre_agent" {
+  count     = var.enable_stage_sre_agent ? 1 : 0
+  type      = "Microsoft.Resources/deployments@2022-09-01"
+  name      = "stage-sre-agent"
+  parent_id = data.azurerm_resource_group.lab.id
+
+  depends_on = [azapi_resource.stage_a]
+
+  body = {
+    properties = {
+      mode     = "Incremental"
+      template = sensitive(jsondecode(file("${path.module}/../infra/stages/60-sre-agent.json")))
+      parameters = {
+        namePrefix = { value = var.name_prefix }
+        ownerTag   = { value = var.owner_tag }
+      }
+    }
+  }
+}

--- a/terraform/stages.tfvars.example
+++ b/terraform/stages.tfvars.example
@@ -38,6 +38,12 @@ enable_stage_ai      = false            # AI (Foundry + models + token alerts)
 ai_location          = "swedencentral"  # region for the Foundry account + models
 router_model_version = "2025-08-07"     # VERIFY: az cognitiveservices account list-models
 
+# Optional SRE Agent stage - preview Azure SRE Agent, connectors, identities, and RBAC.
+# Hard pinned to swedencentral by the Stage 60 Bicep module; depends on Stage A.
+# Off by default because active usage is billable and always-on billing can begin
+# after an eligible trial. The deploying identity needs subscription role-assignment permission.
+enable_stage_sre_agent = false
+
 # Optional preview/GA telemetry features (part of Stage E). Off by default because
 # the DCR and the central LAW must be in the same region and the platform-logs DCR
 # is still in public preview (region-limited). Flip to true once you've confirmed

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -100,6 +100,12 @@ variable "enable_stage_ai" {
   default = false
 }
 
+variable "enable_stage_sre_agent" {
+  type        = bool
+  default     = false
+  description = "Deploy the optional preview Azure SRE Agent stage. The agent is hard pinned to swedencentral and can incur billable usage."
+}
+
 variable "ai_location" {
   type        = string
   default     = "swedencentral"

--- a/workloads/ai/.env.example
+++ b/workloads/ai/.env.example
@@ -8,7 +8,7 @@ AZURE_AI_PROJECT_ENDPOINT=https://<your-foundry-account>.services.ai.azure.com/a
 # Application Insights connection string (enables trace/token/cost export).
 # Get it with:
 #   az monitor app-insights component show --app appi-<namePrefix> -g <resource-group> --query connectionString -o tsv
-APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=<key>;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/
+APPLICATIONINSIGHTS_CONNECTION_STRING=<APPLICATION-INSIGHTS-CONNECTION-STRING>
 
 # Chat model deployment used for the simulated runs (default: gpt-5-mini).
 AZURE_CHAT_DEPLOYMENT=gpt-5-mini


### PR DESCRIPTION
## Summary

- add a dedicated optional Stage 60 deployment for Azure SRE Agent, hard pinned to `swedencentral`
- deploy the same agent, connectors, managed identities, and RBAC through staged Bicep and Terraform AzAPI orchestration
- expose the default-off Terraform toggle through the central config generator and example tfvars
- surface the SRE Agent stage in the root README, Bicep and Terraform guides, reference, stage guide, and customer handout

## Safety and lifecycle

- SRE Agent remains disabled by default
- enabling the stage requires subscription-level role-assignment permission for Monitoring Contributor
- active Agent Unit usage is billable during an eligible trial; fixed always-on billing can begin afterward
- teardown guidance explicitly requires deleting the agent to stop all billing

## Validation

- remote `dev` merges into `master` as an exact fast-forward with no conflicts
- Stage 60 Bicep compiles and matches the tracked ARM JSON
- non-destructive Azure ARM validation passed against the approved lab subscription and resource group
- `terraform fmt -check` and `terraform validate` pass
- isolated Terraform plan includes `azapi_resource.stage_sre_agent[0]` with action `create`
- PowerShell config generation emits `enable_stage_sre_agent = false` by default