### PR TITLE
Add portal-based SLI scenario

### DIFF
--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2057,7 +2057,7 @@ Health Models *require* Service Groups precisely because the same resource may h
 ---
 
 <a id="s46"></a>
-## 46 · Service Level Indicators (SLIs / SLOs) — error budgets on the workload (preview)
+## 46 · Service Level Indicators (SLIs / SLOs) - error budgets on the workload (preview)
 
 **Audience:** SRE leads, platform owners — same crowd as #45, one layer up from "healthy yes/no".
 **Time:** 4–5 min.
@@ -2074,34 +2074,43 @@ Health Models *require* Service Groups precisely because the same resource may h
 | UAMI `id-sli-amlab` + Monitoring Reader + Monitoring Metrics Publisher on `amw-amlab` | `infra/modules/sli-identity.bicep` (auto) | SLI plane needs a UAMI with read on the source AMW and write back to the destination AMW. |
 | Monitoring Metrics Publisher on AMW default DCR + DCE | `scripts/setup-slis.ps1` (auto) | The AMW's auto-created DCR/DCE live in `MA_amw-amlab_<region>_managed`. SLI ingestion fails without grants here too. |
 | Service group `amlab-workload` | `scripts/setup-health-model.ps1` (auto) | Same SG that hosts the Health Model. |
-| SLIs themselves — **created manually in the portal for now** | _(see below)_ | The `Microsoft.Monitor/slis@2025-03-01-preview` RP currently rejects the enum wire values documented in the Bicep schema and the .NET SDK. The lab pre-stages everything the SLI needs; you create the two SLIs in the portal with one click each. |
+| AKS Managed Prometheus source metrics | AKS monitoring add-on (auto) | The setup script verifies `up`, `kube_pod_status_phase`, and the pod-start histogram bucket/count series before the demo. |
+| Sample SLIs | Azure portal (manual) | Create the two preview resources using the field values below. The script intentionally avoids depending on a changing preview API contract. |
 
-> **Why portal-only right now?** This is a preview API. The published schema and the live control-plane validator disagree on enum spellings for `operator` / `comparator`. `setup-slis.ps1` keeps the helper functions in place for the day the spec settles; today it prints a portal URL plus the exact UAMI + AMW IDs you need to paste.
+> The `Microsoft.Monitor/slis` API remains in preview. Portal creation is intentional: the portal tracks current control-plane validation while the script provides stable prerequisite, RBAC, and metric-flow checks.
 
-### Pre-demo: create the two SLIs (one-time, ≈2 min)
+### Pre-demo: verify metrics and create the two SLIs
 
-`scripts/setup-slis.ps1` runs as part of `deploy.ps1` and prints a portal URL + the exact field values. Open the URL it gives you:
+`scripts/setup-slis.ps1` runs as part of `deploy.ps1`, `post-staged-deploy.ps1`, and the Cloud Shell post-deployment wrapper. It verifies the service group, identity, destination permissions, and source metric series, then prints the portal URL and resource IDs:
+
+```powershell
+./scripts/setup-slis.ps1 `
+   -ResourceGroup rg-azure-monitor-lab-one-button120 `
+   -ServiceGroupId amlab-workload
+```
+
+Do not continue if the script reports a missing metric. A successful run confirms that all four documented source metric families currently return at least one series from `amw-amlab`.
 
 > `https://portal.azure.com/#@<tenant>/resource/providers/Microsoft.Management/serviceGroups/amlab-workload/serviceLevelIndicators`
 
-Click **+ Add SLI** twice and fill the two forms with the values the script printed. The cheat-sheet:
+Open the URL, select **+ Add SLI**, and create these definitions:
 
-**SLI #1 — `sli-aks-pods-running`** (Availability, Window-Based)
-- Source AMW: `amw-amlab`, identity = UAMI `id-sli-amlab` (client-ID GUID from the script)
-- Signal s1: `kube_pod_status_phase`, filter `phase == Running`, temporal Average / 5 min, spatial Sum
+**SLI #1: `sli-aks-pods-running`** (Availability, Window-Based)
+- Source AMW: `amw-amlab`, identity = UAMI `id-sli-amlab`
+- Signal s1: `kube_pod_status_phase`, filter `phase == running`, temporal Average / 5 min, spatial Sum
 - Signal s2: `kube_pod_status_phase`, temporal Average / 5 min, spatial Sum
-- **Important:** keep both signal sources' spatial dimensions identical (both empty, or both `[cluster]`). Mis-aligned dimensions fail validation.
-- Signal formula: `(100 * $s1) / $s2`
+- Keep both signal sources' spatial dimensions identical. Use no dimensions or use `cluster` for both.
+- Signal formula: `(100 * s1) / s2`
 - Window uptime criteria: `>= 95`
 - Baseline: `99` / `7d` / RollingDays
 - Destination AMW: `amw-amlab` (same UAMI)
 
-**SLI #2 — `sli-aks-pod-start-latency`** (Latency, Window-Based)
+**SLI #2: `sli-aks-pod-start-latency`** (Latency, Window-Based)
 - Same source AMW + identity
 - Signal s1: `kubelet_pod_start_duration_seconds_bucket`, filter `le == 30`, temporal Rate / 5 min, spatial Sum
 - Signal s2: `kubelet_pod_start_duration_seconds_count`, temporal Rate / 5 min, spatial Sum
-- Same dimensions rule.
-- Signal formula: `(100 * $s1) / $s2`
+- Keep both signal sources' spatial dimensions identical.
+- Signal formula: `(100 * s1) / s2`
 - Window uptime criteria: `>= 95`
 - Baseline: `95` / `7d` / RollingDays
 - Destination AMW: `amw-amlab`
@@ -2109,26 +2118,24 @@ Click **+ Add SLI** twice and fill the two forms with the values the script prin
 > First data points appear ~10-15 min after the SLI saves, once the streaming rule provisions and the destination metrics start emitting in the AMW.
 
 ### Click-through (4 min)
-1. **Portal → Service groups → `amlab-workload` → Service Level Indicators**. You'll see both SLIs created above.
+1. **Portal > Service groups > `amlab-workload` > Service Level Indicators**. Open the two manually created SLIs.
 2. Open `sli-aks-pods-running`:
-   - **Definition** tab — show the formula `(100 × $s1) / $s2`, the two signal sources (running vs total), the uptime criteria `>= 95`, and the SLO baseline (`99` / 7d rolling).
-   - **Compliance** tab — current compliance %, error budget remaining as a sparkline.
-3. Open `sli-aks-pod-start-latency` — same layout, but on a histogram-derived ratio. Point out that Window-Based is the answer for histogram metrics where Request-Based doesn't fit.
-4. Show the **destination metrics** the SLI emits back into the AMW (sliComplianceRatio, sliBaselineRatio, sliErrorBudgetRatio). These can be graphed in Grafana or fed back into the Health Model as additional signals — the "SLO → workload health" closing loop.
+   - **Definition** tab - show the `(100 * s1) / s2` formula, uptime criteria `>= 95`, and SLO baseline (`99` / 7d rolling).
+   - **Compliance** tab - show current compliance and error budget remaining.
+3. Open `sli-aks-pod-start-latency` - show the percentage of pod starts completed within 30 seconds.
+4. Show the **destination metrics** the SLI emits back into the AMW (sliComplianceRatio, sliBaselineRatio, sliErrorBudgetRatio). These can be graphed in Grafana or fed back into the Health Model as additional signals, closing the SLO-to-workload-health loop.
 
 ### Break-the-lab story (≈90 s)
-1. `kubectl scale deployment frontend --replicas=0 -n frontend` — pods stop, `kube_pod_status_phase{phase=Running}` drops.
-2. Wait one or two 5-min windows. `sli-aks-pods-running` compliance drops below `95`. Baseline compliance % starts trending down; error-budget burn becomes visible.
-3. Restore with `kubectl scale deployment frontend --replicas=2 -n frontend`. Compliance recovers within 1–2 windows.
+1. Scale a demo AKS deployment to zero replicas so its running-pod signal drops.
+2. Wait one or two 5-minute windows. `sli-aks-pods-running` compliance drops and error-budget burn becomes visible.
+3. Restore the deployment. Availability compliance recovers after running-pod windows resume.
 
 ### Where it lives in the code
 ```
 infra/modules/sli-identity.bicep   UAMI + role assignments on AMW
 infra/main.bicep                   Wires sliIdentity in + exports outputs
 scripts/setup-slis.ps1             Grants Metrics Publisher on AMW DCR/DCE
-                                   + prints portal handoff (URL + UAMI/AMW IDs).
-                                   SLI PUTs are parked behind a comment until
-                                   the preview-RP enum wire format stabilizes.
+                                   + verifies source metrics + prints portal inputs.
 scripts/deploy.ps1                 Chains setup-health-model.ps1 + setup-slis.ps1
 scripts/teardown.ps1               Tears SLIs down before deleting the RG (idempotent)
 ```
@@ -2142,7 +2149,7 @@ scripts/teardown.ps1               Tears SLIs down before deleting the RG (idemp
 
 ```powershell
 ./scripts/setup-slis.ps1 -Teardown
-# DELETEs both SLI extension resources on the service group. Idempotent.
+# Deletes the two documented portal-created SLIs. Idempotent.
 ```
 
 ### Killer line

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,7 +55,7 @@ For a fresh deployment, use `deploy.ps1` rather than calling `post-deploy.ps1` d
 | `setup-ai-cloud-shell.ps1` | Cloud Shell-specific AI wrapper that pins the subscription and resolves Foundry and Application Insights through ARM without optional Azure CLI extensions. | `./scripts/setup-ai-cloud-shell.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` |
 | `setup-sre-agent.ps1` | Validates the deployed SRE Agent, connectors, and identity-specific RBAC. It discovers the agent identities automatically and is read-only unless `-GrantMissingRoles` is explicitly supplied. | `./scripts/setup-sre-agent.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` |
 | `setup-health-model.ps1` | Creates or removes the optional tenant-scoped Service Group and its RG relationship. | `./scripts/setup-health-model.ps1 -ResourceGroup <rg>` or add `-Teardown` |
-| `setup-slis.ps1` | Creates or removes the optional SLI resources attached to the Health Model Service Group. | `./scripts/setup-slis.ps1 -ResourceGroup <rg>` or add `-Teardown` |
+| `setup-slis.ps1` | Verifies the Service Group, identity permissions, and Managed Prometheus source metrics for portal-created SLIs. `-Teardown` removes the two documented samples. | `./scripts/setup-slis.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` or add `-Teardown` |
 | `setup-rbac-demo.ps1` | Creates the service principals and role assignments used by the granular RBAC demonstration. | `./scripts/setup-rbac-demo.ps1 -ResourceGroup <rg>` |
 | `demo-granular-rbac.ps1` | Runs the granular RBAC demonstration query using the generated local RBAC configuration. | `./scripts/demo-granular-rbac.ps1` |
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -314,10 +314,10 @@ Write-Step "Provisioning service group + RG member (scenario 45 prerequisite)"
 $setupHm = Join-Path $PSScriptRoot 'setup-health-model.ps1'
 & $setupHm -ResourceGroup $ResourceGroup
 
-# 5. Service Level Indicators (scenario 46) — extension on the service group.
-Write-Step "Provisioning demo SLIs (scenario 46)"
+# 5. Verify the portal-created SLI prerequisites and source metrics (scenario 46).
+Write-Step "Verifying demo SLI prerequisites and source metrics (scenario 46)"
 $setupSli = Join-Path $PSScriptRoot 'setup-slis.ps1'
-& $setupSli -ResourceGroup $ResourceGroup
+& $setupSli -SubscriptionId $active.id -ResourceGroup $ResourceGroup
 
 # 6. Optional AI feature — create the demo agents + simulate GenAI traffic, but only
 #    when lab.config.json enabled it (stageToggles.enableStageAI -> Bicep enableAi).

--- a/scripts/post-cloud-shell-deploy.ps1
+++ b/scripts/post-cloud-shell-deploy.ps1
@@ -80,7 +80,7 @@ Write-Step "Running App Service and AKS post-deployment setup"
 Write-Step "Provisioning service group and health model prerequisites"
 & (Join-Path $PSScriptRoot 'setup-health-model.ps1') -ResourceGroup $ResourceGroup
 
-Write-Step "Provisioning demo SLI prerequisites"
-& (Join-Path $PSScriptRoot 'setup-slis.ps1') -ResourceGroup $ResourceGroup
+Write-Step "Verifying demo SLI prerequisites and source metrics"
+& (Join-Path $PSScriptRoot 'setup-slis.ps1') -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup
 
 Write-Host "`nCloud Shell post-deployment setup completed." -ForegroundColor Green

--- a/scripts/post-staged-deploy.ps1
+++ b/scripts/post-staged-deploy.ps1
@@ -85,9 +85,9 @@ Write-Step "Provisioning service group and health model prerequisites"
 $setupHm = Join-Path $PSScriptRoot 'setup-health-model.ps1'
 & $setupHm -ResourceGroup $ResourceGroup
 
-Write-Step "Provisioning demo SLI prerequisites"
+Write-Step "Verifying demo SLI prerequisites and source metrics"
 $setupSli = Join-Path $PSScriptRoot 'setup-slis.ps1'
-& $setupSli -ResourceGroup $ResourceGroup
+& $setupSli -SubscriptionId $active.id -ResourceGroup $ResourceGroup
 
 $labConfigPath = Join-Path $PSScriptRoot '..' 'lab.config.json'
 $sreAgentEnabled = $false

--- a/scripts/setup-slis.ps1
+++ b/scripts/setup-slis.ps1
@@ -1,293 +1,203 @@
 <#
 .SYNOPSIS
-  Prepare the lab for demo Service Level Indicators (Microsoft.Monitor/slis
-  preview) on the lab's service group — scenario 46.
+  Prepare and verify the lab prerequisites for portal-created Service Level
+  Indicators (Microsoft.Monitor/slis preview), scenario 46.
 
 .DESCRIPTION
-  Microsoft.Monitor/slis is an *extension* resource on a tenant-scoped service
-  group, so it can't live in RG-scoped Bicep. The 2025-03-01-preview RP also
-  currently rejects the enum wire values documented in both the Bicep schema
-  and the generated .NET SDK (e.g. `operator: '=='`, `comparator: '>='`), so
-  scripted PUTs are parked until the spec stabilizes. This script does the
-  prep that the SLI plane actually needs (which is non-trivial), then prints a
-  portal URL and the exact field values to paste into the portal SLI form.
+  The SLI resource provider is preview and its control-plane contract can
+  change independently of the portal. This script deliberately does not create
+  SLIs. It verifies the service group, locates the SLI identity and Azure
+  Monitor Workspace, grants the destination ingestion permissions, confirms
+  the documented Managed Prometheus metrics are flowing, and prints the exact
+  values needed to create the sample SLIs in the Azure portal.
 
-  Steps:
-    1. Verify the service group exists (created by setup-health-model.ps1).
-    2. Look up the UAMI 'id-sli-amlab' + AMW 'amw-amlab' by name.
-    3. Grant Monitoring Metrics Publisher on the AMW's default DCR + DCE
-       (the AMW role grant from Bicep is not enough — the SLI plane writes
-        through the DCR in the managed RG `MA_<amw>_<region>_managed`).
-    4. Print the portal URL and the UAMI/AMW IDs needed to fill the SLI form.
-
-    -Teardown deletes the two SLIs by their canonical names. Idempotent —
-    safe to run whether or not SLIs were created in the portal.
+  The script is idempotent. Re-running it verifies the same prerequisites and
+  reuses existing role assignments.
 
 .PARAMETER ResourceGroup
-  Lab resource group containing the AMW + UAMI.
+  Lab resource group containing the Azure Monitor Workspace and SLI identity.
+
+.PARAMETER SubscriptionId
+  Expected Azure subscription. Required when .azure-target.json is absent.
 
 .PARAMETER ServiceGroupId
-  Service group that owns the SLIs (created by setup-health-model.ps1).
+  Service group that owns the portal-created SLIs.
 
 .PARAMETER Teardown
-  Delete the two SLIs (by canonical name). Idempotent.
+  Delete the documented sample SLIs if they were created in the portal.
 
-.NOTES
-  API version: Microsoft.Monitor/slis  2025-03-01-preview
-  RBAC required to run this script:
-    * Reader on the lab RG.
-    * User Access Administrator (or Owner) on the AMW's managed RG, so the
-      script can grant Monitoring Metrics Publisher on its DCR + DCE.
-  When PUTs are restored, you'll additionally need Owner/Contributor on the
-  service group to write the SLI extension resources.
+.PARAMETER MetricWaitMinutes
+  Maximum time to wait for all required Managed Prometheus source metrics.
 #>
 [CmdletBinding()]
 param(
   [string] $ResourceGroup  = 'rg-azure-monitor-lab',
+  [string] $SubscriptionId,
   [string] $ServiceGroupId = 'amlab-workload',
+  [ValidateRange(0, 60)]
+  [int] $MetricWaitMinutes = 10,
   [switch] $Teardown
 )
 
 $ErrorActionPreference = 'Stop'
-function Write-Step($msg) { Write-Host "`n==> $msg" -ForegroundColor Cyan }
-function Write-Info($msg) { Write-Host "    $msg" -ForegroundColor DarkGray }
-function Write-Warn($msg) { Write-Host "    $msg" -ForegroundColor Yellow }
+function Write-Step($Message) { Write-Host "`n==> $Message" -ForegroundColor Cyan }
+function Write-Info($Message) { Write-Host "    $Message" -ForegroundColor DarkGray }
 
-# --- Subscription guardrail ----------------------------------------------------
+# Subscription guardrail
 $targetFile = Join-Path $PSScriptRoot '..' '.azure-target.json'
 if (Test-Path $targetFile) {
   $target = Get-Content -Raw $targetFile | ConvertFrom-Json
-  az account set --subscription $target.expectedSubscriptionId | Out-Null
-  $active = az account show --query "{id:id, tenantId:tenantId}" -o json | ConvertFrom-Json
-  if ($active.id -ne $target.expectedSubscriptionId -or $active.tenantId -ne $target.expectedTenantId) {
-    throw "BLOCKED: not on allowed lab subscription. Aborting."
+  if ($SubscriptionId -and $SubscriptionId -ne $target.expectedSubscriptionId) {
+    throw "BLOCKED: -SubscriptionId '$SubscriptionId' does not match .azure-target.json '$($target.expectedSubscriptionId)'."
   }
+  $SubscriptionId = $target.expectedSubscriptionId
 } else {
-  $active = az account show --query "{id:id, tenantId:tenantId}" -o json | ConvertFrom-Json
+  if (-not $SubscriptionId) {
+    throw 'BLOCKED: specify -SubscriptionId when .azure-target.json is absent.'
+  }
+  $target = $null
+}
+
+az account set --subscription $SubscriptionId | Out-Null
+$active = az account show --query "{id:id, tenantId:tenantId}" -o json | ConvertFrom-Json
+if ($active.id -ne $SubscriptionId) {
+  throw "BLOCKED: active subscription '$($active.id)' does not match expected subscription '$SubscriptionId'."
+}
+if ($target -and $active.tenantId -ne $target.expectedTenantId) {
+  throw "BLOCKED: active tenant '$($active.tenantId)' does not match expected tenant '$($target.expectedTenantId)'."
 }
 Write-Info "Sub: $($active.id)"
 Write-Info "RG : $ResourceGroup"
 Write-Info "SG : $ServiceGroupId"
 
-# --- API constants -------------------------------------------------------------
 $sliApi = '2025-03-01-preview'
-$sgApi  = '2024-02-01-preview'
-$sgUrl  = "https://management.azure.com/providers/Microsoft.Management/serviceGroups/$ServiceGroupId" + "?api-version=$sgApi"
+$sgApi = '2024-02-01-preview'
+$sgUrl = "https://management.azure.com/providers/Microsoft.Management/serviceGroups/$ServiceGroupId" + "?api-version=$sgApi"
 
 function Get-SliUrl {
   param([string] $SliName)
   return "https://management.azure.com/providers/Microsoft.Management/serviceGroups/$ServiceGroupId/providers/Microsoft.Monitor/slis/$SliName" + "?api-version=$sliApi"
 }
 
-# ===============================================================================
-# TEARDOWN
-# ===============================================================================
 if ($Teardown) {
-  Write-Step "Teardown: removing demo SLIs"
-  foreach ($sli in @('sli-aks-pods-running', 'sli-aks-pod-start-latency')) {
-    $url = Get-SliUrl -SliName $sli
-    Write-Info "DELETE $url"
-    az rest --method delete --url $url --only-show-errors 2>$null | Out-Null
+  Write-Step 'Removing documented sample SLIs'
+  foreach ($sliName in @('sli-aks-pods-running', 'sli-aks-pod-start-latency')) {
+    az rest --method delete --url (Get-SliUrl -SliName $sliName) --only-show-errors 2>$null | Out-Null
+    Write-Info "Delete submitted: $sliName"
   }
-  Write-Host "`nTeardown submitted (DELETE is idempotent)." -ForegroundColor Green
+  Write-Host "`nTeardown submitted. DELETE is idempotent." -ForegroundColor Green
   return
 }
 
-# ===============================================================================
-# PREREQ — verify service group exists
-# ===============================================================================
-Write-Step "Verifying service group '$ServiceGroupId' exists"
-$sgState = az rest --method get --url $sgUrl --only-show-errors 2>$null | ConvertFrom-Json
-if (-not $sgState -or $sgState.properties.provisioningState -ne 'Succeeded') {
-  throw "Service group '$ServiceGroupId' not found or not in Succeeded state. Run scripts/setup-health-model.ps1 first."
+Write-Step "Verifying service group '$ServiceGroupId'"
+$serviceGroup = az rest --method get --url $sgUrl --only-show-errors 2>$null | ConvertFrom-Json
+if (-not $serviceGroup -or $serviceGroup.properties.provisioningState -ne 'Succeeded') {
+  throw "Service group '$ServiceGroupId' was not found in Succeeded state. Run scripts/setup-health-model.ps1 first."
 }
-Write-Info "Service group OK ($($sgState.properties.provisioningState))."
+Write-Info "Service group state: $($serviceGroup.properties.provisioningState)"
 
-# ===============================================================================
-# PREREQ — locate UAMI + AMW by name (more robust than scanning deployments)
-# ===============================================================================
-Write-Step "Locating UAMI 'id-sli-amlab' and AMW 'amw-amlab' in $ResourceGroup"
-
-$uamiId = az identity show -g $ResourceGroup -n 'id-sli-amlab' --query id -o tsv 2>$null
-if (-not $uamiId) {
-  throw "User-Assigned MI 'id-sli-amlab' not found in '$ResourceGroup'. Re-run deploy.ps1 with the latest main.bicep (the sli-identity module must have run)."
-}
-$uamiClientId = az identity show -g $ResourceGroup -n 'id-sli-amlab' --query clientId -o tsv 2>$null
-if (-not $uamiClientId) {
-  throw "Could not read clientId for UAMI 'id-sli-amlab'."
+Write-Step "Locating SLI identity and Azure Monitor Workspace in '$ResourceGroup'"
+$uami = az identity show -g $ResourceGroup -n id-sli-amlab --query '{id:id,clientId:clientId,principalId:principalId}' -o json 2>$null | ConvertFrom-Json
+if (-not $uami.id -or -not $uami.clientId -or -not $uami.principalId) {
+  throw "User-assigned identity 'id-sli-amlab' was not found or is incomplete in '$ResourceGroup'."
 }
 
-$amwId = az resource show -g $ResourceGroup -n 'amw-amlab' --resource-type 'Microsoft.Monitor/accounts' --query id -o tsv 2>$null
-if (-not $amwId) {
-  throw "Azure Monitor Workspace 'amw-amlab' not found in '$ResourceGroup'."
+$amw = az resource show -g $ResourceGroup -n amw-amlab --resource-type Microsoft.Monitor/accounts -o json 2>$null | ConvertFrom-Json
+if (-not $amw.id) {
+  throw "Azure Monitor Workspace 'amw-amlab' was not found in '$ResourceGroup'."
 }
-$amwName  = 'amw-amlab'
-$location = az group show -n $ResourceGroup --query location -o tsv
-Write-Info "UAMI    : $uamiId"
-Write-Info "UAMI cid: $uamiClientId"
-Write-Info "AMW     : $amwId ($amwName) @ $location"
+Write-Info "UAMI: $($uami.id)"
+Write-Info "AMW : $($amw.id)"
 
-$uamiPrincipalId = az identity show -g $ResourceGroup -n 'id-sli-amlab' --query principalId -o tsv 2>$null
-if (-not $uamiPrincipalId) {
-  throw "Could not read principalId for UAMI 'id-sli-amlab'."
+Write-Step 'Ensuring SLI destination ingestion permissions'
+$ingestion = $amw.properties.defaultIngestionSettings
+if (-not $ingestion.dataCollectionRuleResourceId) {
+  throw "Azure Monitor Workspace 'amw-amlab' has no default ingestion DCR."
 }
 
-# ===============================================================================
-# PREREQ — grant Monitoring Metrics Publisher on the AMW's default DCR + DCE
-# (the AMW role assignment is not enough; the SLI plane writes through the DCR
-#  in the managed resource group MA_<amw>_<region>_managed).
-# ===============================================================================
-Write-Step "Granting Monitoring Metrics Publisher on AMW default DCR + DCE"
-
-$ingest = az resource show --ids $amwId --query 'properties.defaultIngestionSettings' -o json | ConvertFrom-Json
-if (-not $ingest.dataCollectionRuleResourceId) {
-  throw "AMW '$amwName' has no defaultIngestionSettings.dataCollectionRuleResourceId."
-}
-$dcrId = $ingest.dataCollectionRuleResourceId
-$dceId = $ingest.dataCollectionEndpointResourceId
-$metricsPublisherRoleId = '3913510d-42f4-4e42-8a64-420c390055eb'  # Monitoring Metrics Publisher
-Write-Info "DCR : $dcrId"
-Write-Info "DCE : $dceId"
-
-foreach ($scope in @($dcrId, $dceId)) {
+$metricsPublisherRoleId = '3913510d-42f4-4e42-8a64-420c390055eb'
+foreach ($scope in @($ingestion.dataCollectionRuleResourceId, $ingestion.dataCollectionEndpointResourceId)) {
   if (-not $scope) { continue }
-  $existing = az role assignment list --assignee-object-id $uamiPrincipalId --assignee-principal-type ServicePrincipal --scope $scope --role $metricsPublisherRoleId --query "[0].id" -o tsv 2>$null
+  $assignments = az role assignment list --assignee-object-id $uami.principalId --scope $scope -o json 2>$null | ConvertFrom-Json
+  $existing = $assignments | Where-Object { $_.roleDefinitionId -like "*/$metricsPublisherRoleId" } | Select-Object -First 1
   if ($existing) {
-    Write-Info "Already assigned on $($scope.Split('/')[-3..-1] -join '/')"
-  } else {
-    Write-Info "Assigning Monitoring Metrics Publisher on $($scope.Split('/')[-3..-1] -join '/')"
-    az role assignment create --assignee-object-id $uamiPrincipalId --assignee-principal-type ServicePrincipal --role $metricsPublisherRoleId --scope $scope --only-show-errors | Out-Null
+    Write-Info "Monitoring Metrics Publisher already assigned on $scope"
+    continue
   }
-}
-Write-Info "Waiting 30s for role propagation..."
-Start-Sleep -Seconds 30
 
-# ===============================================================================
-# Helper to build + PUT an SLI body
-# ===============================================================================
-function New-SignalSource {
-  param(
-    [string] $Id,
-    [string] $MetricName,
-    [string] $MetricNamespace = 'default',
-    [array]  $Filters = @(),
-    [string] $TemporalType = 'Increase',
-    [int]    $WindowSizeMinutes = 5,
-    [string] $SpatialType = 'Sum'
-  )
-  return [pscustomobject]@{
-    signalSourceId                  = $Id
-    metricName                      = $MetricName
-    metricNamespace                 = $MetricNamespace
-    filters                         = @($Filters)
-    sourceAmwAccountResourceId      = $amwId
-    sourceAmwAccountManagedIdentity = $uamiClientId
-    temporalAggregation             = @{ type = $TemporalType; windowSizeMinutes = $WindowSizeMinutes }
-    spatialAggregation              = @{ type = $SpatialType;  dimensions = @() }
+  az role assignment create `
+    --assignee-object-id $uami.principalId `
+    --assignee-principal-type ServicePrincipal `
+    --role $metricsPublisherRoleId `
+    --scope $scope `
+    --only-show-errors | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to assign Monitoring Metrics Publisher on '$scope'."
   }
+  Write-Info "Assigned Monitoring Metrics Publisher on $scope"
 }
 
-function Submit-Sli {
-  param(
-    [string] $Name,
-    [hashtable] $Body
-  )
-  $url = Get-SliUrl -SliName $Name
-  $tmp = New-TemporaryFile
-  ($Body | ConvertTo-Json -Depth 20 -Compress) | Set-Content -Path $tmp -Encoding UTF8
-  Write-Info "PUT $url"
-  # `az rest` writes errors to stderr but exits 0 — capture combined output and
-  # check $LASTEXITCODE *and* the response for an error envelope before polling.
-  $putOutput = & az rest --method put --url $url --body "@$tmp" 2>&1
-  Remove-Item $tmp -Force -ErrorAction SilentlyContinue
-  if ($LASTEXITCODE -ne 0 -or ($putOutput -join "`n") -match 'ERROR: ') {
-    throw "Failed to PUT SLI '$Name'.`n$putOutput"
-  }
-
-  # Poll for terminal state
-  $deadline = (Get-Date).AddSeconds(180)
-  while ((Get-Date) -lt $deadline) {
-    Start-Sleep -Seconds 5
-    $resp = az rest --method get --url $url --only-show-errors 2>$null | ConvertFrom-Json
-    $state = $resp.properties.provisioningState
-    Write-Info "$Name : provisioningState = $state"
-    if ($state -eq 'Succeeded') { return }
-    if ($state -in 'Failed','Canceled') {
-      throw "SLI '$Name' ended in state '$state'. Response: $($resp | ConvertTo-Json -Depth 8)"
-    }
-  }
-  Write-Warn "SLI '$Name' did not reach Succeeded within 180s — continuing anyway. Re-check in the portal."
+Write-Step 'Verifying Managed Prometheus source metrics'
+$queryEndpoint = $amw.properties.metrics.prometheusQueryEndpoint
+if (-not $queryEndpoint) {
+  throw "Azure Monitor Workspace 'amw-amlab' has no Prometheus query endpoint."
 }
 
-# ===============================================================================
-# SLI bodies (parked) — portal-driven creation for now
-# ===============================================================================
-# Why: the Microsoft.Monitor/slis 2025-03-01-preview RP currently rejects the
-# enum wire values documented in both the Bicep schema and the generated .NET
-# SDK (e.g. operator '==' and comparator '>='), and the published OpenAPI
-# spec / SDK source disagree with the live control-plane validator. Without a
-# captured portal payload to mirror exactly, scripted SLI creation is a
-# coin-flip. Everything *around* the SLI is set up correctly by this script
-# (UAMI, role assignments on AMW + DCR + DCE, service group), so the operator
-# only needs to fill in the form fields below in the portal.
-#
-# Once a known-good portal payload is captured (F12 -> Network -> PUT body
-# on the .../slis/<name> request), restore Submit-Sli + the two SLI blocks
-# kept in git history (commit 043fb73 and the preview-debug attempts after).
-#
-# Tracking: this is a preview API. Re-evaluate at GA.
+$metricQueries = [ordered]@{
+  'up' = 'up'
+  'kube_pod_status_phase' = 'kube_pod_status_phase'
+  'kubelet_pod_start_duration_seconds_bucket{le="30"}' = 'kubelet_pod_start_duration_seconds_bucket{le="30"}'
+  'kubelet_pod_start_duration_seconds_count' = 'kubelet_pod_start_duration_seconds_count'
+}
+$metricDeadline = (Get-Date).AddMinutes($MetricWaitMinutes)
+do {
+  $queryToken = az account get-access-token --resource https://prometheus.monitor.azure.com --query accessToken -o tsv
+  if (-not $queryToken) {
+    throw 'Could not acquire an Azure Monitor Prometheus query token.'
+  }
 
-Write-Step "SLI bodies parked — create the two SLIs in the portal"
-$portalSgUrl = "https://portal.azure.com/#@$($active.tenantId)/resource/providers/Microsoft.Management/serviceGroups/$ServiceGroupId/serviceLevelIndicators"
+  $metricCounts = @{}
+  foreach ($entry in $metricQueries.GetEnumerator()) {
+    $query = [uri]::EscapeDataString($entry.Value)
+    $response = Invoke-RestMethod `
+      -Method Get `
+      -Uri "$queryEndpoint/api/v1/query?query=$query" `
+      -Headers @{ Authorization = "Bearer $queryToken" } `
+      -TimeoutSec 30
+    $seriesCount = @($response.data.result).Count
+    $metricCounts[$entry.Key] = $seriesCount
+    Write-Info "$($entry.Key): $seriesCount series"
+  }
+
+  $missingMetrics = @($metricQueries.Keys | Where-Object { $metricCounts[$_] -eq 0 })
+  if ($missingMetrics.Count -gt 0 -and (Get-Date) -lt $metricDeadline) {
+    Write-Info "Waiting 30 seconds for Managed Prometheus propagation: $($missingMetrics -join ', ')"
+    Start-Sleep -Seconds 30
+  }
+} while ($missingMetrics.Count -gt 0 -and (Get-Date) -lt $metricDeadline)
+
+if ($missingMetrics.Count -gt 0) {
+  throw "Required Managed Prometheus metrics did not appear within $MetricWaitMinutes minute(s): $($missingMetrics -join ', '). Verify AKS Managed Prometheus collection, then rerun this script."
+}
+
+$portalUrl = "https://portal.azure.com/#@$($active.tenantId)/resource/providers/Microsoft.Management/serviceGroups/$ServiceGroupId/serviceLevelIndicators"
 Write-Host @"
 
-   Open: $portalSgUrl
+SLI prerequisites verified. Create the sample SLIs in the portal:
 
-   Click '+ Add SLI' twice and paste these values:
+  Portal       : $portalUrl
+  Service group: $ServiceGroupId
+  Source AMW   : $($amw.id)
+  Destination  : $($amw.id)
+  Identity     : $($uami.id)
+  Client ID    : $($uami.clientId)
 
-   --- SLI #1 : sli-aks-pods-running (Availability, Window-Based) -----------
-   Category                   Availability
-   Evaluation type            Window-based
-   Source AMW                 $amwName  ($amwId)
-   Source AMW managed identity (UAMI client ID below)
-   Metric 1 (s1)              kube_pod_status_phase   filter: phase == Running
-                              temporal: Average / 5 min   spatial: Sum
-   Metric 2 (s2)              kube_pod_status_phase
-                              temporal: Average / 5 min   spatial: Sum
-   Signal formula             (100 * `$s1) / `$s2
-   Window uptime criteria     >= 95
-   Baseline                   99   / 7d   / RollingDays
-   Destination AMW            $amwName  (same UAMI)
+Suggested source metrics:
+  Availability: kube_pod_status_phase, filtered to phase=running
+  Latency     : kubelet_pod_start_duration_seconds_bucket, filtered to le=30
+                kubelet_pod_start_duration_seconds_count
 
-   --- SLI #2 : sli-aks-pod-start-latency (Latency, Window-Based) -----------
-   Category                   Latency
-   Evaluation type            Window-based
-   Source AMW                 $amwName  ($amwId)
-   Source AMW managed identity (UAMI client ID below)
-   Metric 1 (s1)              kubelet_pod_start_duration_seconds_bucket
-                              filter: le == 30
-                              temporal: Rate / 5 min      spatial: Sum
-   Metric 2 (s2)              kubelet_pod_start_duration_seconds_count
-                              temporal: Rate / 5 min      spatial: Sum
-   Signal formula             (100 * `$s1) / `$s2
-   Window uptime criteria     >= 95
-   Baseline                   95   / 7d   / RollingDays
-   Destination AMW            $amwName  (same UAMI)
-
-   --- Values to paste -----------------------------------------------------
-   UAMI client ID             $uamiClientId
-   UAMI resource ID           $uamiId
-   UAMI principal (object) ID $uamiPrincipalId
-   AMW resource ID            $amwId
-   AMW default DCR            $dcrId
-   AMW default DCE            $dceId
-
-   IMPORTANT — when adding multiple signal sources, keep their spatial
-   aggregation 'dimensions' identical (both empty, or both ['cluster'], etc).
-   Mis-aligned dimensions fail validation with [SignalSourceValidator].
-
-   To remove the UAMI + role assignments (after deleting the SLIs in portal):
-     ./scripts/teardown.ps1
+All four documented source metrics are currently flowing. See scenario 46 in
+docs/DEMO-SCENARIOS.md for the complete portal field values.
 
 "@ -ForegroundColor Green
-return


### PR DESCRIPTION
## Summary
- replace unreliable preview API SLI creation with portal-based instructions
- verify the Service Group, managed identity permissions, and required AKS Managed Prometheus metrics
- add bounded metric propagation retries and explicit subscription validation
- align deployment entry points, teardown names, and script documentation

## Validation
- PowerShell parser validation passed for all changed scripts
- `dotnet build azure-monitor-demo-lab.sln --nologo` passed with 0 warnings and 0 errors
- live validation passed in `rg-azure-monitor-lab-one-button120`
- verified `up`, `kube_pod_status_phase`, and pod-start histogram metrics are flowing
- `git diff --check` passed

## Notes
- SLI resources remain portal-created while `Microsoft.Monitor/slis` is in preview
- no SLI resources were created or deleted during validation
- targets `dev`; `main` remains unchanged pending approval