### PR TITLE
Fix SLI portal formula instructions

### DIFF
--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2085,12 +2085,12 @@ Health Models *require* Service Groups precisely because the same resource may h
 
 ```powershell
 ./scripts/start-the-lab.ps1 `
-   -ResourceGroup rg-azure-monitor-lab-one-button120 `
+   -ResourceGroup rg-azure-monitor-lab-sre-agent-8-9 `
    -Wait
 
 ./scripts/setup-slis.ps1 `
    -SubscriptionId 794194cd-a4b7-4024-970c-9533c4babff0 `
-   -ResourceGroup rg-azure-monitor-lab-one-button120 `
+   -ResourceGroup rg-azure-monitor-lab-sre-agent-8-9 `
    -ServiceGroupId amlab-workload
 ```
 
@@ -2099,6 +2099,8 @@ The AKS cluster must be running before the portal can preview these signals. Aft
 > `https://portal.azure.com/#@<tenant>/resource/providers/Microsoft.Management/serviceGroups/amlab-workload/serviceLevelIndicators`
 
 Open the URL, select **+ Add SLI**, and create these definitions:
+
+> Resource names are reused across lab deployments. In both portal pickers, verify the full resource ID and select `amw-amlab` and `id-sli-amlab` from `rg-azure-monitor-lab-sre-agent-8-9`. Selecting identically named resources from another RG can leave Signal Preview empty.
 
 **SLI #1: `sli-aks-pods-running`** (Availability, Window-Based)
 - Source AMW: `amw-amlab`, identity = UAMI `id-sli-amlab`

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2085,6 +2085,7 @@ Health Models *require* Service Groups precisely because the same resource may h
 
 ```powershell
 ./scripts/setup-slis.ps1 `
+   -SubscriptionId 794194cd-a4b7-4024-970c-9533c4babff0 `
    -ResourceGroup rg-azure-monitor-lab-one-button120 `
    -ServiceGroupId amlab-workload
 ```
@@ -2097,30 +2098,30 @@ Open the URL, select **+ Add SLI**, and create these definitions:
 
 **SLI #1: `sli-aks-pods-running`** (Availability, Window-Based)
 - Source AMW: `amw-amlab`, identity = UAMI `id-sli-amlab`
-- Signal s1: `kube_pod_status_phase`, filter `phase == running`, temporal Average / 5 min, spatial Sum
-- Signal s2: `kube_pod_status_phase`, temporal Average / 5 min, spatial Sum
-- Keep both signal sources' spatial dimensions identical. Use no dimensions or use `cluster` for both.
-- Signal formula: `(100 * s1) / s2`
+- Signal A: metric `kube_pod_status_phase`, metric aggregation `Average`, filter `phase eq running`, **Summarize `Sum` for dimension `cluster`**
+- Signal B: metric `kube_pod_status_phase`, metric aggregation `Average`, no filter, **Summarize `Sum` for dimension `cluster`**
+- Signal formula: `(100 * A) / B`. Signal IDs are uppercase and the formula must use uppercase letters.
 - Window uptime criteria: `>= 95`
 - Baseline: `99` / `7d` / RollingDays
 - Destination AMW: `amw-amlab` (same UAMI)
 
 **SLI #2: `sli-aks-pod-start-latency`** (Latency, Window-Based)
 - Same source AMW + identity
-- Signal s1: `kubelet_pod_start_duration_seconds_bucket`, filter `le == 30`, temporal Rate / 5 min, spatial Sum
-- Signal s2: `kubelet_pod_start_duration_seconds_count`, temporal Rate / 5 min, spatial Sum
-- Keep both signal sources' spatial dimensions identical.
-- Signal formula: `(100 * s1) / s2`
+- Signal A: metric `kubelet_pod_start_duration_seconds_bucket`, metric aggregation `Rate`, filter `le eq 30`, **Summarize `Sum` for dimension `cluster`**
+- Signal B: metric `kubelet_pod_start_duration_seconds_count`, metric aggregation `Rate`, no filter, **Summarize `Sum` for dimension `cluster`**
+- Signal formula: `(100 * A) / B`. Signal IDs are uppercase and the formula must use uppercase letters.
 - Window uptime criteria: `>= 95`
 - Baseline: `95` / `7d` / RollingDays
 - Destination AMW: `amw-amlab`
+
+> The portal requires every signal in a formula to use the same spatial aggregation configuration. For both Signal A and Signal B, select **Summarize = Sum** and **dimension = cluster**. Choosing Average for one signal and Sum for the other produces the "different spatial aggregation types" validation error.
 
 > First data points appear ~10-15 min after the SLI saves, once the streaming rule provisions and the destination metrics start emitting in the AMW.
 
 ### Click-through (4 min)
 1. **Portal > Service groups > `amlab-workload` > Service Level Indicators**. Open the two manually created SLIs.
 2. Open `sli-aks-pods-running`:
-   - **Definition** tab - show the `(100 * s1) / s2` formula, uptime criteria `>= 95`, and SLO baseline (`99` / 7d rolling).
+   - **Definition** tab - show the `(100 * A) / B` formula, uptime criteria `>= 95`, and SLO baseline (`99` / 7d rolling).
    - **Compliance** tab - show current compliance and error budget remaining.
 3. Open `sli-aks-pod-start-latency` - show the percentage of pod starts completed within 30 seconds.
 4. Show the **destination metrics** the SLI emits back into the AMW (sliComplianceRatio, sliBaselineRatio, sliErrorBudgetRatio). These can be graphed in Grafana or fed back into the Health Model as additional signals, closing the SLO-to-workload-health loop.

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2084,13 +2084,17 @@ Health Models *require* Service Groups precisely because the same resource may h
 `scripts/setup-slis.ps1` runs as part of `deploy.ps1`, `post-staged-deploy.ps1`, and the Cloud Shell post-deployment wrapper. It verifies the service group, identity, destination permissions, and source metric series, then prints the portal URL and resource IDs:
 
 ```powershell
+./scripts/start-the-lab.ps1 `
+   -ResourceGroup rg-azure-monitor-lab-one-button120 `
+   -Wait
+
 ./scripts/setup-slis.ps1 `
    -SubscriptionId 794194cd-a4b7-4024-970c-9533c4babff0 `
    -ResourceGroup rg-azure-monitor-lab-one-button120 `
    -ServiceGroupId amlab-workload
 ```
 
-Do not continue if the script reports a missing metric. A successful run confirms that all four documented source metric families currently return at least one series from `amw-amlab`.
+The AKS cluster must be running before the portal can preview these signals. After a stopped cluster starts, allow Managed Prometheus time to emit fresh samples. Do not continue if `setup-slis.ps1` reports a missing metric. A successful run confirms that all four documented source metric families currently return at least one series from `amw-amlab`.
 
 > `https://portal.azure.com/#@<tenant>/resource/providers/Microsoft.Management/serviceGroups/amlab-workload/serviceLevelIndicators`
 

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2084,13 +2084,16 @@ Health Models *require* Service Groups precisely because the same resource may h
 `scripts/setup-slis.ps1` runs as part of `deploy.ps1`, `post-staged-deploy.ps1`, and the Cloud Shell post-deployment wrapper. It verifies the service group, identity, destination permissions, and source metric series, then prints the portal URL and resource IDs:
 
 ```powershell
+$subscriptionId = '<subscription-id>'
+$resourceGroup = '<resource-group>'
+
 ./scripts/start-the-lab.ps1 `
-   -ResourceGroup rg-azure-monitor-lab-sre-agent-8-9 `
+   -ResourceGroup $resourceGroup `
    -Wait
 
 ./scripts/setup-slis.ps1 `
-   -SubscriptionId 794194cd-a4b7-4024-970c-9533c4babff0 `
-   -ResourceGroup rg-azure-monitor-lab-sre-agent-8-9 `
+   -SubscriptionId $subscriptionId `
+   -ResourceGroup $resourceGroup `
    -ServiceGroupId amlab-workload
 ```
 
@@ -2100,7 +2103,7 @@ The AKS cluster must be running before the portal can preview these signals. Aft
 
 Open the URL, select **+ Add SLI**, and create these definitions:
 
-> Resource names are reused across lab deployments. In both portal pickers, verify the full resource ID and select `amw-amlab` and `id-sli-amlab` from `rg-azure-monitor-lab-sre-agent-8-9`. Selecting identically named resources from another RG can leave Signal Preview empty.
+> Resource names are reused across lab deployments. In both portal pickers, verify the full resource ID and select `amw-amlab` and `id-sli-amlab` from the target resource group. Selecting identically named resources from another RG can leave Signal Preview empty.
 
 **SLI #1: `sli-aks-pods-running`** (Availability, Window-Based)
 - Source AMW: `amw-amlab`, identity = UAMI `id-sli-amlab`
@@ -2121,6 +2124,8 @@ Open the URL, select **+ Add SLI**, and create these definitions:
 - Destination AMW: `amw-amlab`
 
 > The portal requires every signal in a formula to use the same spatial aggregation configuration. For both Signal A and Signal B, select **Summarize = Sum** and **dimension = cluster**. Choosing Average for one signal and Sum for the other produces the "different spatial aggregation types" validation error.
+
+> Select **Validate** after entering the signals and formula. The Signal Preview pane is populated by validation and can show "Could not find appropriate columns for Line Chart" before the first successful validation. Treat an error returned by **Validate**, rather than the pre-validation preview placeholder, as the configuration result.
 
 > First data points appear ~10-15 min after the SLI saves, once the streaming rule provisions and the destination metrics start emitting in the AMW.
 

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2136,11 +2136,22 @@ kubectl -n demo rollout status deployment/hello-frontend
 
 First data points can take 10-15 minutes to appear after a valid source window, once the streaming rule provisions and the destination metrics start emitting in the AMW.
 
+### Reading error budget and burn rate
+
+Azure Monitor compares the measured SLI with the **baseline target**, which is the SLO. The gap between perfect reliability and that target is the allowed unreliability. For example, a `99%` baseline provides a `1%` error budget over the selected evaluation period.
+
+- **Error Budget Remaining** shows how much of that allowed unreliability is still available before the service misses its baseline target. It answers: *"How much more failure can we absorb?"* A falling value means unsuccessful requests or bad windows are consuming the budget. An exhausted budget means there is no remaining tolerance for failure within the evaluation period.
+- **Burn Rate** shows how quickly the error budget is being consumed. It answers: *"At the current rate, how urgently do we need to act?"* A fast-burn condition usually indicates a sudden regression. A slow-burn condition indicates sustained degradation that can still cause an SLO miss if it continues.
+- **Use them together:** Error Budget Remaining describes the reliability margin left; Burn Rate describes the urgency. A healthy remaining budget with a sharp fast burn can require immediate action, while a gradual slow burn calls for investigation before it becomes an SLO miss.
+
+Azure Monitor can alert when the SLI falls below its baseline, when a fast burn consumes budget rapidly over a short lookback, or when a slow burn persists over a longer lookback. See [Service level indicators in Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/fundamentals/service-level-indicators-create#understand-baseline-target-error-budget-and-burn-rate).
+
 ### Click-through (4 min)
 1. **Portal > Service groups > `amlab-workload` > Service Level Indicators**. Open the two manually created SLIs.
 2. Open `sli-aks-pods-running`:
    - **Definition** tab - show the `(100 * A) / B` formula, uptime criteria `>= 95`, and SLO baseline (`99` / 7d rolling).
-   - **Compliance** tab - show current compliance and error budget remaining.
+   - **Compliance** tab - show current compliance and error budget remaining. Explain that remaining budget is the failure margin left before the SLO is missed.
+   - **Burn Rate** - explain that this is the speed of budget consumption: fast burn points to a sudden regression; slow burn points to sustained degradation.
 3. Open `sli-aks-pod-start-latency` - show the percentage of pod starts completed within 30 seconds.
 4. Show the **destination metrics** the SLI emits back into the AMW: `<sli-name>:Value`, `<sli-name>:Uptime`, and `<sli-name>:Downtime`, in the service-group metric namespace. These can be graphed in Grafana or fed back into the Health Model as additional signals, closing the SLO-to-workload-health loop.
 
@@ -2153,7 +2164,7 @@ First data points can take 10-15 minutes to appear after a valid source window, 
 ```
 infra/modules/sli-identity.bicep   UAMI + role assignments on AMW
 infra/main.bicep                   Wires sliIdentity in + exports outputs
-scripts/setup-slis.ps1             Grants Metrics Publisher on AMW DCR/DCE
+scripts/setup-slis.ps1             Verifies source and destination RBAC on the AMW/DCR/DCE
                                    + verifies source metrics + prints portal inputs.
 scripts/deploy.ps1                 Chains setup-health-model.ps1 + setup-slis.ps1
 scripts/teardown.ps1               Tears SLIs down before deleting the RG (idempotent)

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2116,8 +2116,8 @@ Open the URL, select **+ Add SLI**, and create these definitions:
 
 **SLI #2: `sli-aks-pod-start-latency`** (Latency, Window-Based)
 - Same source AMW + identity
-- Signal A: metric `kubelet_pod_start_duration_seconds_bucket`, metric aggregation `Rate`, filter `le eq 30`, **Summarize `Sum` for dimension `cluster`**
-- Signal B: metric `kubelet_pod_start_duration_seconds_count`, metric aggregation `Rate`, no filter, **Summarize `Sum` for dimension `cluster`**
+- Signal A: metric `kubelet_pod_start_duration_seconds_bucket`, metric aggregation `Rate` over `5` minutes, filter `le eq 30`, **Summarize `Sum` for dimension `cluster`**
+- Signal B: metric `kubelet_pod_start_duration_seconds_count`, metric aggregation `Rate` over `5` minutes, no filter, **Summarize `Sum` for dimension `cluster`**
 - Signal formula: `(100 * A) / B`. Signal IDs are uppercase and the formula must use uppercase letters.
 - Window uptime criteria: `>= 95`
 - Baseline: `95` / `7d` / RollingDays
@@ -2127,7 +2127,14 @@ Open the URL, select **+ Add SLI**, and create these definitions:
 
 > Select **Validate** after entering the signals and formula. The Signal Preview pane is populated by validation and can show "Could not find appropriate columns for Line Chart" before the first successful validation. Treat an error returned by **Validate**, rather than the pre-validation preview placeholder, as the configuration result.
 
-> First data points appear ~10-15 min after the SLI saves, once the streaming rule provisions and the destination metrics start emitting in the AMW.
+The pod-start histogram counters only change when pods start. After creating the latency SLI, generate fresh samples with a rolling restart that keeps the deployment available:
+
+```powershell
+kubectl -n demo rollout restart deployment/hello-frontend
+kubectl -n demo rollout status deployment/hello-frontend
+```
+
+First data points can take 10-15 minutes to appear after a valid source window, once the streaming rule provisions and the destination metrics start emitting in the AMW.
 
 ### Click-through (4 min)
 1. **Portal > Service groups > `amlab-workload` > Service Level Indicators**. Open the two manually created SLIs.
@@ -2135,7 +2142,7 @@ Open the URL, select **+ Add SLI**, and create these definitions:
    - **Definition** tab - show the `(100 * A) / B` formula, uptime criteria `>= 95`, and SLO baseline (`99` / 7d rolling).
    - **Compliance** tab - show current compliance and error budget remaining.
 3. Open `sli-aks-pod-start-latency` - show the percentage of pod starts completed within 30 seconds.
-4. Show the **destination metrics** the SLI emits back into the AMW (sliComplianceRatio, sliBaselineRatio, sliErrorBudgetRatio). These can be graphed in Grafana or fed back into the Health Model as additional signals, closing the SLO-to-workload-health loop.
+4. Show the **destination metrics** the SLI emits back into the AMW: `<sli-name>:Value`, `<sli-name>:Uptime`, and `<sli-name>:Downtime`, in the service-group metric namespace. These can be graphed in Grafana or fed back into the Health Model as additional signals, closing the SLO-to-workload-health loop.
 
 ### Break-the-lab story (≈90 s)
 1. Scale a demo AKS deployment to zero replicas so its running-pod signal drops.

--- a/scripts/setup-slis.ps1
+++ b/scripts/setup-slis.ps1
@@ -120,6 +120,7 @@ $metricsPublisherRoleId = '3913510d-42f4-4e42-8a64-420c390055eb'
 $roleRequirements = @(
   [pscustomobject]@{ Name = 'Monitoring Reader'; Id = $monitoringReaderRoleId; Scope = $amw.id }
   [pscustomobject]@{ Name = 'Monitoring Metrics Publisher'; Id = $metricsPublisherRoleId; Scope = $amw.id }
+  [pscustomobject]@{ Name = 'Monitoring Reader'; Id = $monitoringReaderRoleId; Scope = $ingestion.dataCollectionRuleResourceId }
   [pscustomobject]@{ Name = 'Monitoring Metrics Publisher'; Id = $metricsPublisherRoleId; Scope = $ingestion.dataCollectionRuleResourceId }
   [pscustomobject]@{ Name = 'Monitoring Metrics Publisher'; Id = $metricsPublisherRoleId; Scope = $ingestion.dataCollectionEndpointResourceId }
 )

--- a/scripts/setup-slis.ps1
+++ b/scripts/setup-slis.ps1
@@ -109,32 +109,40 @@ if (-not $amw.id) {
 Write-Info "UAMI: $($uami.id)"
 Write-Info "AMW : $($amw.id)"
 
-Write-Step 'Ensuring SLI destination ingestion permissions'
+Write-Step 'Ensuring SLI source and destination permissions'
 $ingestion = $amw.properties.defaultIngestionSettings
 if (-not $ingestion.dataCollectionRuleResourceId) {
   throw "Azure Monitor Workspace 'amw-amlab' has no default ingestion DCR."
 }
 
+$monitoringReaderRoleId = '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
 $metricsPublisherRoleId = '3913510d-42f4-4e42-8a64-420c390055eb'
-foreach ($scope in @($ingestion.dataCollectionRuleResourceId, $ingestion.dataCollectionEndpointResourceId)) {
-  if (-not $scope) { continue }
-  $assignments = az role assignment list --assignee-object-id $uami.principalId --scope $scope -o json 2>$null | ConvertFrom-Json
-  $existing = $assignments | Where-Object { $_.roleDefinitionId -like "*/$metricsPublisherRoleId" } | Select-Object -First 1
+$roleRequirements = @(
+  [pscustomobject]@{ Name = 'Monitoring Reader'; Id = $monitoringReaderRoleId; Scope = $amw.id }
+  [pscustomobject]@{ Name = 'Monitoring Metrics Publisher'; Id = $metricsPublisherRoleId; Scope = $amw.id }
+  [pscustomobject]@{ Name = 'Monitoring Metrics Publisher'; Id = $metricsPublisherRoleId; Scope = $ingestion.dataCollectionRuleResourceId }
+  [pscustomobject]@{ Name = 'Monitoring Metrics Publisher'; Id = $metricsPublisherRoleId; Scope = $ingestion.dataCollectionEndpointResourceId }
+)
+
+foreach ($requirement in $roleRequirements) {
+  if (-not $requirement.Scope) { continue }
+  $assignments = az role assignment list --assignee-object-id $uami.principalId --scope $requirement.Scope -o json 2>$null | ConvertFrom-Json
+  $existing = $assignments | Where-Object { $_.roleDefinitionId -like "*/$($requirement.Id)" } | Select-Object -First 1
   if ($existing) {
-    Write-Info "Monitoring Metrics Publisher already assigned on $scope"
+    Write-Info "$($requirement.Name) already assigned on $($requirement.Scope)"
     continue
   }
 
   az role assignment create `
     --assignee-object-id $uami.principalId `
     --assignee-principal-type ServicePrincipal `
-    --role $metricsPublisherRoleId `
-    --scope $scope `
+    --role $requirement.Id `
+    --scope $requirement.Scope `
     --only-show-errors | Out-Null
   if ($LASTEXITCODE -ne 0) {
-    throw "Failed to assign Monitoring Metrics Publisher on '$scope'."
+    throw "Failed to assign $($requirement.Name) on '$($requirement.Scope)'."
   }
-  Write-Info "Assigned Monitoring Metrics Publisher on $scope"
+  Write-Info "Assigned $($requirement.Name) on $($requirement.Scope)"
 }
 
 Write-Step 'Verifying Managed Prometheus source metrics'


### PR DESCRIPTION
## Fix
Corrects Scenario 46 to match the current SLI portal form:

- use uppercase signal IDs `A` and `B` in formulas
- use `(100 * A) / B`
- set **Summarize = Sum** for both signals
- select the `cluster` dimension for both signals
- distinguish metric aggregation from the spatial Summarize control
- include the required `-SubscriptionId` in the setup command

This resolves both portal errors reported during SLI creation:

- lowercase letters are not allowed in formulas
- Signal A and Signal B have different spatial aggregation types

## Validation
- stale lowercase formulas and old filter forms no longer appear in Scenario 46
- `git diff --check` passed