### PR TITLE
Document one-button SLI portal handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Opens a guided Custom deployment wizard in the Azure Portal, where you enter eve
 | **Monitoring & cost** | Daily ingestion cap, Sentinel, platform-logs/metrics-export DCRs, LAW replication |
 | **Advanced** | Owner tag, App Service sample repo, optional SIEM/Teams webhook, optional AI and SRE Agent stages |
 
-After the portal deployment succeeds, open **Cloud Shell** in the Azure portal, select **PowerShell**, and run the commands below. The Cloud Shell wrapper discovers the deployed resources, publishes the App Service sample, and installs the AKS, Health Model, and SLI demo components without requiring optional Azure CLI extensions:
+After the portal deployment succeeds, open **Cloud Shell** in the Azure portal, select **PowerShell**, and run the commands below. The Cloud Shell wrapper discovers the deployed resources, publishes the App Service sample, installs the AKS and Health Model demo components, and verifies the identity, RBAC, and Managed Prometheus prerequisites for the SLI demo without requiring optional Azure CLI extensions:
 
 ```powershell
 git clone https://github.com/claestom/azure-monitor-demo-lab.git
@@ -71,6 +71,8 @@ $resourceGroup = Read-Host 'Resource group name'
 az account set --subscription $subscriptionId
 ./scripts/post-cloud-shell-deploy.ps1 -SubscriptionId $subscriptionId -ResourceGroup $resourceGroup
 ```
+
+> **SLI manual step:** The Deploy to Azure button and Cloud Shell wrapper do not create the two preview SLI resources. After the wrapper reports that all four source metrics are flowing, open the SLI portal URL it prints and create `sli-aks-pods-running` and `sli-aks-pod-start-latency` using the field values in [Scenario 46](docs/DEMO-SCENARIOS.md#s46). Use the `amw-amlab` workspace and `id-sli-amlab` identity from the resource group you deployed. Allow 10-15 minutes after a valid source window for the evaluated SLI metrics to appear.
 
 If the repository is already present in Cloud Shell, update it before rerunning the wrapper:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,10 +14,10 @@ Most scripts use the Azure CLI and require `az login`. Scripts that work with AK
 |---|---|---|
 | `sync-config.ps1` | Reads `lab.config.json` and generates the gitignored deployment inputs: `.azure-target.json`, `infra/main.parameters.json`, and `terraform/stages.tfvars`. | `./scripts/sync-config.ps1` |
 | `preflight-check.ps1` | Checks regional SKU availability, quota, and Azure resource-provider availability before deployment. | `./scripts/preflight-check.ps1 -Location northeurope` |
-| `deploy.ps1` | Runs the one-shot Bicep deployment, including resource creation, post-deployment workloads, health model setup, SLIs, optional AI setup, and optional SRE Agent deployment and validation. | `./scripts/deploy.ps1 -ResourceGroup rg-my-lab -Location northeurope` |
+| `deploy.ps1` | Runs the one-shot Bicep deployment, including resource creation, post-deployment workloads, health model setup, SLI prerequisite verification, optional AI setup, and optional SRE Agent deployment and validation. The preview SLIs remain a manual portal step. | `./scripts/deploy.ps1 -ResourceGroup rg-my-lab -Location northeurope` |
 | `post-deploy.ps1` | Publishes the .NET sample to App Service and applies the AKS frontend, load generator, and OpenTelemetry workloads. Normally called by `deploy.ps1`. | `./scripts/post-deploy.ps1 -ResourceGroup <rg> -WebAppName <app> -AksName <aks> -WebAppHost <host>` |
 | `post-staged-deploy.ps1` | After a staged Bicep or Terraform deployment, discovers the App Service, AKS cluster, and central LAW, then runs the setup used by `deploy.ps1`. | `./scripts/post-staged-deploy.ps1 -ResourceGroup <rg>` |
-| `post-cloud-shell-deploy.ps1` | Cloud Shell-specific portal wrapper that pins the subscription and resolves Application Insights through ARM without optional Azure CLI extensions. | `./scripts/post-cloud-shell-deploy.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` |
+| `post-cloud-shell-deploy.ps1` | Cloud Shell-specific portal wrapper that pins the subscription, configures workloads, and verifies SLI prerequisites. It prints the manual portal handoff because preview SLIs are not created automatically. | `./scripts/post-cloud-shell-deploy.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` |
 | `gen-architecture-svg.ps1` | Regenerates `docs/architecture-overview-sre.svg` from the architecture definition and local Azure icons. | `./scripts/gen-architecture-svg.ps1` |
 
 For a fresh deployment, use `deploy.ps1` rather than calling `post-deploy.ps1` directly.

--- a/scripts/post-cloud-shell-deploy.ps1
+++ b/scripts/post-cloud-shell-deploy.ps1
@@ -83,4 +83,16 @@ Write-Step "Provisioning service group and health model prerequisites"
 Write-Step "Verifying demo SLI prerequisites and source metrics"
 & (Join-Path $PSScriptRoot 'setup-slis.ps1') -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup
 
-Write-Host "`nCloud Shell post-deployment setup completed." -ForegroundColor Green
+Write-Host @"
+
+Cloud Shell post-deployment setup completed.
+
+Manual SLI step still required:
+  1. Open the SLI portal URL printed above.
+  2. Create sli-aks-pods-running and sli-aks-pod-start-latency.
+  3. Use amw-$NamePrefix and id-sli-$NamePrefix from resource group '$ResourceGroup'.
+  4. Follow Scenario 46 in docs/DEMO-SCENARIOS.md for the exact fields and warm-up step.
+
+The Deploy to Azure button and this wrapper prepare SLI prerequisites but do not
+create the Microsoft.Monitor/slis preview resources.
+"@ -ForegroundColor Green


### PR DESCRIPTION
## Summary
Clarifies the manual SLI step after a Deploy to Azure button deployment.

- explains in the main one-button instructions that the wrapper prepares SLI prerequisites but does not create preview SLI resources
- names the two SLIs users must create and links Scenario 46
- prints the same handoff when `post-cloud-shell-deploy.ps1` completes
- corrects the script catalog so it no longer implies automatic SLI creation

## Validation
- PowerShell parser validation passed for `post-cloud-shell-deploy.ps1`
- Scenario 46 link target `#s46` exists
- `git diff --check` passed