### PR TITLE
Delete related resource groups during teardown

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,9 +30,9 @@ For a fresh deployment, use `deploy.ps1` rather than calling `post-deploy.ps1` d
 | `break-the-lab.ps1` | Intentionally degrades the lab: stops VMs, crashloops the AKS frontend, and increases load-generator failures. | `./scripts/break-the-lab.ps1 -ResourceGroup <rg>` |
 | `restore-the-lab.ps1` | Reverses the break scenario by starting VMs, restoring the AKS image, and applying a healthy load generator. | `./scripts/restore-the-lab.ps1 -ResourceGroup <rg>` |
 | `start-ramp.ps1` | Starts a 60-minute AKS load test against the App Service for Smart Detection and autoscale demonstrations. | `./scripts/start-ramp.ps1 -ResourceGroup <rg>` |
-| `teardown.ps1` | Removes tenant-scoped demo artifacts, disables LAW replication, removes nested DCR associations, deletes DCRs and DCEs where possible, then deletes the resource group. | `./scripts/teardown.ps1 -ResourceGroup <rg> -Yes` |
+| `teardown.ps1` | Removes tenant-scoped demo artifacts and monitoring dependencies, then deletes every resource group whose name contains the complete requested resource group name, including AKS-managed `MC_` groups. | `./scripts/teardown.ps1 -ResourceGroup <rg> -Yes` |
 
-`teardown.ps1` is destructive. The `-Yes` switch skips the confirmation prompt. If omitted, the script requires you to type `DELETE`.
+`teardown.ps1` is destructive. It lists all matching resource groups before deletion. The `-Yes` switch skips the confirmation prompt. If omitted, the script requires you to type `DELETE`.
 
 ## Telemetry and monitoring demos
 

--- a/scripts/teardown.ps1
+++ b/scripts/teardown.ps1
@@ -9,6 +9,26 @@ param(
 )
 $ErrorActionPreference = 'Stop'
 
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
+  throw 'ResourceGroup cannot be empty.'
+}
+
+function Remove-MatchingResourceGroups {
+  param([string[]] $Names)
+
+  foreach ($name in $Names) {
+    Write-Host "Deleting $name ..." -ForegroundColor Yellow
+    az group delete -n $name --yes --no-wait
+    if ($LASTEXITCODE -ne 0) {
+      throw "Azure CLI failed to submit deletion for resource group '$name'."
+    }
+  }
+
+  Write-Host "Delete requests accepted (running in background)." -ForegroundColor Green
+  Write-Host "Verify completion with:" -ForegroundColor Green
+  $Names | ForEach-Object { Write-Host "  az group exists -n '$_'" -ForegroundColor Green }
+}
+
 # Subscription guardrail
 $targetFile = Join-Path $PSScriptRoot '..' '.azure-target.json'
 if (Test-Path $targetFile) {
@@ -20,9 +40,38 @@ if (Test-Path $targetFile) {
   }
 }
 
+# Include Azure-managed and auxiliary resource groups whose names contain the
+# complete requested RG name, such as MC_<rg>_<aks>_<region>.
+$allResourceGroupNames = @(az group list --query '[].name' -o json | ConvertFrom-Json)
+if ($LASTEXITCODE -ne 0) {
+  throw 'Failed to list resource groups for teardown discovery.'
+}
+$resourceGroupsToDelete = @(
+  $allResourceGroupNames |
+    Where-Object { $_.IndexOf($ResourceGroup, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 } |
+    Sort-Object { if ($_ -ieq $ResourceGroup) { 0 } else { 1 } }, { $_ }
+)
+
+if ($resourceGroupsToDelete.Count -eq 0) {
+  Write-Host "No resource groups contain '$ResourceGroup'. Nothing to delete." -ForegroundColor Yellow
+  return
+}
+
 if (-not $Yes) {
-  $confirm = Read-Host "About to delete RG '$ResourceGroup' and EVERYTHING in it. Type DELETE to confirm"
+  Write-Host "The following resource groups contain '$ResourceGroup' and will be deleted:" -ForegroundColor Yellow
+  $resourceGroupsToDelete | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
+  $confirm = Read-Host 'Type DELETE to confirm deletion of every resource group listed above'
   if ($confirm -ne 'DELETE') { Write-Host "Aborted." -ForegroundColor Yellow; return }
+} else {
+  Write-Host "Deleting resource groups whose names contain '$ResourceGroup':" -ForegroundColor Yellow
+  $resourceGroupsToDelete | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
+}
+
+$primaryResourceGroupExists = @($allResourceGroupNames | Where-Object { $_ -ieq $ResourceGroup }).Count -gt 0
+if (-not $primaryResourceGroupExists) {
+  Write-Host "The original resource group no longer exists; deleting matched auxiliary resource groups directly." -ForegroundColor Yellow
+  Remove-MatchingResourceGroups -Names $resourceGroupsToDelete
+  return
 }
 
 # Delete billable SRE Agent resources explicitly before the asynchronous RG delete.
@@ -99,10 +148,4 @@ if (Test-Path $setupHm) {
   & $setupHm -ResourceGroup $ResourceGroup -Teardown
 }
 
-Write-Host "Deleting $ResourceGroup ..." -ForegroundColor Yellow
-az group delete -n $ResourceGroup --yes --no-wait
-if ($LASTEXITCODE -ne 0) {
-  throw "Azure CLI failed to submit deletion for resource group '$ResourceGroup'."
-}
-Write-Host "Delete request accepted (running in background)." -ForegroundColor Green
-Write-Host "Verify completion with: az group exists -n $ResourceGroup" -ForegroundColor Green
+Remove-MatchingResourceGroups -Names $resourceGroupsToDelete


### PR DESCRIPTION
## Summary
- discover resource groups whose names contain the complete requested resource group name
- include Azure-managed AKS resource groups such as MC_<rg>_<aks>_<region>
- preserve the existing cleanup path and support orphaned auxiliary groups
- list all matched groups before confirmation and validate each delete submission

## Validation
- PowerShell parser validation passed
- git diff --check passed
- live test against rg-azure-monitor-lab-one-button-110 matched and submitted deletion for both the primary and MC_ resource groups
- both resource groups entered the Deleting state