### PR TITLE
Add reproducible SLI degradation demo

### DIFF
--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -2127,7 +2127,7 @@ Open the URL, select **+ Add SLI**, and create these definitions:
 
 > Select **Validate** after entering the signals and formula. The Signal Preview pane is populated by validation and can show "Could not find appropriate columns for Line Chart" before the first successful validation. Treat an error returned by **Validate**, rather than the pre-validation preview placeholder, as the configuration result.
 
-The pod-start histogram counters only change when pods start. After creating the latency SLI, generate fresh samples with a rolling restart that keeps the deployment available:
+The pod-start histogram counters only change when pods start. A rolling restart generates fresh samples while keeping the deployment available, but healthy starts normally leave the latency SLI at 100%:
 
 ```powershell
 kubectl -n demo rollout restart deployment/hello-frontend
@@ -2156,9 +2156,41 @@ Azure Monitor can alert when the SLI falls below its baseline, when a fast burn 
 4. Show the **destination metrics** the SLI emits back into the AMW: `<sli-name>:Value`, `<sli-name>:Uptime`, and `<sli-name>:Downtime`, in the service-group metric namespace. These can be graphed in Grafana or fed back into the Health Model as additional signals, closing the SLO-to-workload-health loop.
 
 ### Break-the-lab story (≈90 s)
-1. Scale a demo AKS deployment to zero replicas so its running-pod signal drops.
-2. Wait one or two 5-minute windows. `sli-aks-pods-running` compliance drops and error-budget burn becomes visible.
-3. Restore the deployment. Availability compliance recovers after running-pod windows resume.
+Use the dedicated helper to move both SLIs without changing `hello-frontend`:
+
+```powershell
+./scripts/demo-slis.ps1 `
+   -SubscriptionId $subscriptionId `
+   -ResourceGroup $resourceGroup `
+   -Mode Degrade
+```
+
+The script replaces two temporary deployments in the `demo` namespace, so each `Degrade` run generates fresh pod-start samples:
+
+- `sli-unavailable` creates five pods that remain Pending because the image tag intentionally does not exist. This adds non-running pod states and lowers `sli-aks-pods-running`.
+- `sli-slow-start` creates three pods with a 45-second init-container delay. These starts fall outside the SLI's 30-second latency bucket and lower `sli-aks-pod-start-latency` during the active rate window.
+
+Inspect the test workloads at any time:
+
+```powershell
+./scripts/demo-slis.ps1 `
+   -SubscriptionId $subscriptionId `
+   -ResourceGroup $resourceGroup `
+   -Mode Status
+```
+
+Allow one or two 5-minute source windows plus the SLI processing delay. The live latency value is event-driven and can recover after the slow starts leave the five-minute source window. Seven-day compliance and error-budget changes are more gradual.
+
+Restore both signals by deleting only the temporary test deployments:
+
+```powershell
+./scripts/demo-slis.ps1 `
+   -SubscriptionId $subscriptionId `
+   -ResourceGroup $resourceGroup `
+   -Mode Restore
+```
+
+Do not scale `hello-frontend` to zero for this test. When its pod series disappear, the formula can lose both numerator and denominator instead of producing a clear bad ratio.
 
 ### Where it lives in the code
 ```
@@ -2166,6 +2198,7 @@ infra/modules/sli-identity.bicep   UAMI + role assignments on AMW
 infra/main.bicep                   Wires sliIdentity in + exports outputs
 scripts/setup-slis.ps1             Verifies source and destination RBAC on the AMW/DCR/DCE
                                    + verifies source metrics + prints portal inputs.
+scripts/demo-slis.ps1              Creates, inspects, or removes temporary SLI degradation workloads.
 scripts/deploy.ps1                 Chains setup-health-model.ps1 + setup-slis.ps1
 scripts/teardown.ps1               Tears SLIs down before deleting the RG (idempotent)
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,6 +56,7 @@ For a fresh deployment, use `deploy.ps1` rather than calling `post-deploy.ps1` d
 | `setup-sre-agent.ps1` | Validates the deployed SRE Agent, connectors, and identity-specific RBAC. It discovers the agent identities automatically and is read-only unless `-GrantMissingRoles` is explicitly supplied. | `./scripts/setup-sre-agent.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` |
 | `setup-health-model.ps1` | Creates or removes the optional tenant-scoped Service Group and its RG relationship. | `./scripts/setup-health-model.ps1 -ResourceGroup <rg>` or add `-Teardown` |
 | `setup-slis.ps1` | Verifies the Service Group, identity permissions, and Managed Prometheus source metrics for portal-created SLIs. `-Teardown` removes the two documented samples. | `./scripts/setup-slis.ps1 -SubscriptionId <sub> -ResourceGroup <rg>` or add `-Teardown` |
+| `demo-slis.ps1` | Creates, inspects, or removes isolated AKS workloads that move the availability and pod-start latency SLIs. | `./scripts/demo-slis.ps1 -SubscriptionId <sub> -ResourceGroup <rg> -Mode Degrade` |
 | `setup-rbac-demo.ps1` | Discovers the central LAW and RG-specific custom role, then creates the service principals and role assignments used by the granular RBAC demonstration. | `./scripts/setup-rbac-demo.ps1 -ResourceGroup <rg>` |
 | `demo-granular-rbac.ps1` | Runs the granular RBAC demonstration query using the generated local RBAC configuration. | `./scripts/demo-granular-rbac.ps1` |
 

--- a/scripts/demo-slis.ps1
+++ b/scripts/demo-slis.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+  Creates, inspects, or removes temporary AKS workloads that move the demo SLIs.
+
+.DESCRIPTION
+  Degrade creates two isolated deployments in the demo namespace:
+  - sli-unavailable creates Pending pods with an intentionally invalid image.
+  - sli-slow-start creates pods whose init container waits longer than the
+    30-second pod-start latency threshold.
+
+  Status lists the test deployments and pods. Restore removes only those two
+  deployments. The script does not modify the hello-frontend deployment.
+
+.PARAMETER SubscriptionId
+  Expected Azure subscription ID. Must match the active account after pinning.
+
+.PARAMETER ResourceGroup
+  Resource group containing the target AKS cluster.
+
+.PARAMETER Mode
+  Degrade, Status, or Restore. Defaults to Degrade.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)] [string] $SubscriptionId,
+  [Parameter(Mandatory)] [string] $ResourceGroup,
+  [ValidateSet('Degrade', 'Status', 'Restore')]
+  [string] $Mode = 'Degrade',
+  [string] $Namespace = 'demo'
+)
+
+$ErrorActionPreference = 'Stop'
+function Write-Step($Message) { Write-Host "`n==> $Message" -ForegroundColor Cyan }
+function Assert-NativeCommandSucceeded($Operation) {
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Operation failed with exit code $LASTEXITCODE."
+  }
+}
+
+Write-Step "Pinning Azure subscription"
+az account set --subscription $SubscriptionId | Out-Null
+Assert-NativeCommandSucceeded 'Setting the Azure subscription'
+$activeSubscriptionId = az account show --query id -o tsv
+Assert-NativeCommandSucceeded 'Reading the active Azure subscription'
+if ($activeSubscriptionId -ne $SubscriptionId) {
+  throw "BLOCKED: active subscription '$activeSubscriptionId' does not match expected subscription '$SubscriptionId'."
+}
+
+Write-Step "Connecting to AKS in '$ResourceGroup'"
+$aksClusters = @(az aks list -g $ResourceGroup -o json | ConvertFrom-Json)
+Assert-NativeCommandSucceeded 'Finding the AKS cluster'
+if ($aksClusters.Count -ne 1) {
+  throw "Expected exactly one AKS cluster in '$ResourceGroup', found $($aksClusters.Count)."
+}
+$aks = $aksClusters[0]
+if ($aks.powerState.code -ne 'Running') {
+  throw "AKS cluster '$($aks.name)' is '$($aks.powerState.code)'. Start it before running the SLI demo."
+}
+az aks get-credentials -g $ResourceGroup -n $aks.name --overwrite-existing --output none
+Assert-NativeCommandSucceeded "Connecting kubectl to '$($aks.name)'"
+kubectl get namespace $Namespace --output name | Out-Null
+Assert-NativeCommandSucceeded "Finding namespace '$Namespace'"
+
+$testDeployments = @('sli-unavailable', 'sli-slow-start')
+
+if ($Mode -eq 'Restore') {
+  Write-Step "Removing SLI test deployments"
+  kubectl delete deployment $testDeployments -n $Namespace --ignore-not-found
+  Assert-NativeCommandSucceeded 'Removing the SLI test deployments'
+  Write-Host "`nSLI test workloads removed. Source metrics should recover after the next evaluation windows." -ForegroundColor Green
+  return
+}
+
+if ($Mode -eq 'Status') {
+  Write-Step "Showing SLI test workloads"
+  kubectl get deployment,pod -n $Namespace -l 'amlab-scenario=sli-degradation' -o wide
+  Assert-NativeCommandSucceeded 'Showing the SLI test workloads'
+  return
+}
+
+Write-Step "Replacing reversible SLI degradation workloads"
+kubectl delete deployment $testDeployments -n $Namespace --ignore-not-found --wait=true
+Assert-NativeCommandSucceeded 'Removing previous SLI degradation workloads'
+
+$manifest = @'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sli-unavailable
+  namespace: demo
+  labels:
+    amlab-scenario: sli-degradation
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: sli-unavailable
+  template:
+    metadata:
+      labels:
+        app: sli-unavailable
+        amlab-scenario: sli-degradation
+    spec:
+      containers:
+      - name: unavailable
+        image: mcr.microsoft.com/azuredocs/aks-helloworld:does-not-exist
+        resources:
+          requests:
+            cpu: 5m
+            memory: 8Mi
+          limits:
+            cpu: 20m
+            memory: 32Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sli-slow-start
+  namespace: demo
+  labels:
+    amlab-scenario: sli-degradation
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: sli-slow-start
+  template:
+    metadata:
+      labels:
+        app: sli-slow-start
+        amlab-scenario: sli-degradation
+    spec:
+      initContainers:
+      - name: startup-delay
+        image: busybox:1.36
+        command: ["sh", "-c", "sleep 45"]
+        resources:
+          requests:
+            cpu: 5m
+            memory: 8Mi
+          limits:
+            cpu: 20m
+            memory: 32Mi
+      containers:
+      - name: app
+        image: busybox:1.36
+        command: ["sh", "-c", "sleep 3600"]
+        resources:
+          requests:
+            cpu: 5m
+            memory: 8Mi
+          limits:
+            cpu: 20m
+            memory: 32Mi
+'@
+
+$renderedManifest = $manifest.Replace('namespace: demo', "namespace: $Namespace")
+$manifestPath = Join-Path $env:TEMP "amlab-sli-demo-$([guid]::NewGuid().ToString('N')).yaml"
+try {
+  $renderedManifest | Set-Content -Path $manifestPath -Encoding utf8
+  kubectl apply -f $manifestPath
+  Assert-NativeCommandSucceeded 'Applying the SLI degradation workloads'
+} finally {
+  Remove-Item $manifestPath -Force -ErrorAction SilentlyContinue
+}
+
+Write-Step "Waiting for the slow-start deployment"
+kubectl rollout status deployment/sli-slow-start -n $Namespace --timeout=3m
+Assert-NativeCommandSucceeded 'Waiting for the slow-start deployment'
+
+Write-Step "Current SLI test workload status"
+kubectl get deployment,pod -n $Namespace -l 'amlab-scenario=sli-degradation' -o wide
+Assert-NativeCommandSucceeded 'Showing the SLI test workloads'
+
+Write-Host @"
+
+The availability test pods intentionally remain Pending. The slow-start pods
+started after a 45-second init delay. Allow one or two 5-minute source windows
+and the SLI processing delay before evaluating Compliance and Burn Rate.
+
+Restore with:
+  ./scripts/demo-slis.ps1 -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -Mode Restore
+"@ -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

- add a reusable PowerShell script for inducing and restoring App Service and AKS SLI degradation
- document prerequisites, demo flow, verification, recovery, and troubleshooting
- add the SLI demo script to the scripts reference

## Validation

- branch contains one focused commit relative to master
- script supports status, degrade, restore, and demo workflows