### PR TITLE
Improve SRE Agent incident review and table plan demo

### DIFF
--- a/docs/CUSTOMER-STAGE-HANDOUT.md
+++ b/docs/CUSTOMER-STAGE-HANDOUT.md
@@ -20,7 +20,7 @@ This one-pager helps customers decide how far to go in a workshop or pilot.
 | Stage D - Security posture | Monitor-native detections for drift, IAM changes, exfil signals (scenarios 27, 47, 48, 49) | 5-12 min | EUR 0-15 | AzureActivity ingestion and scheduled query alerts |
 | Stage E - Optional advanced add-ons | Sentinel/reliability/archival extras (scenarios 43, 44, 45, 46) | 10-20 min | EUR 0-40 | Sentinel analytics usage, archive/restore/search workloads, preview feature telemetry |
 | Stage AI - Optional GenAI workload | Microsoft Foundry account + models (chat/embed/optimize/router), token alerts, AI FinOps observability | 5-10 min + traffic | EUR 5-30 | Per-token model usage while the traffic simulator runs (small at capacity 10; stop it to zero it out); minimal idle cost |
-| Stage SRE Agent - Optional incident investigation | Azure SRE Agent investigation and Review-mode response workflows (scenarios 54-58) | 5-10 min + portal setup | Variable; check current SRE Agent pricing | Active Agent Unit usage during an eligible 30-day always-on charge waiver; fixed always-on and usage charges after the waiver |
+| Stage SRE Agent - Optional incident investigation | Azure SRE Agent investigation and Review-mode response workflows (scenarios 54-59) | 5-10 min + portal setup | Variable; check current SRE Agent pricing | Active Agent Unit usage during an eligible 30-day always-on charge waiver; fixed always-on and usage charges after the waiver |
 
 ## Cumulative monthly range by stop point
 

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -25,7 +25,7 @@ Pick a workload (or theme) and run only those scenarios. Each row links to the n
 | **Security** | <ul><li>[27](#s27) Granular RBAC</li><li>[43](#s43) Sentinel</li><li>[44](#s44) Search jobs + Restore</li><li>[47](#s47) Control-plane drift watch</li><li>[48](#s48) Privilege escalation watch</li><li>[49](#s49) Exfil early warning</li></ul> |
 | **AI / ML in Azure Monitor** | <ul><li>[16](#s16) Copilot</li><li>[13](#s13) Smart Detection</li><li>[17](#s17) Dynamic Thresholds</li><li>[18](#s18) Code Optimizations</li><li>[19](#s19) Predictive autoscale</li></ul> |
 | **GenAI observability (optional AI stage)** | <ul><li>[53](#s53) AI FinOps — token / trace / cost</li></ul> |
-| **Azure SRE Agent (optional trial)** | <ul><li>[54](#s54) Trial readiness</li><li>[55](#s55) Alert-driven App Service investigation</li><li>[56](#s56) AKS crash-loop diagnosis</li><li>[57](#s57) Change correlation</li><li>[58](#s58) Alert merging and verified recovery</li><li>[59](#s59) Evidence-backed post-incident review</li></ul> |
+| **Azure SRE Agent (optional trial)** | <ul><li>[54](#s54) Trial readiness</li><li>[55](#s55) Alert-driven App Service investigation</li><li>[56](#s56) AKS crash-loop diagnosis</li><li>[57](#s57) Change correlation</li><li>[58](#s58) Alert merging and verified recovery</li><li>[59](#s59) Automatic incident command brief</li></ul> |
 | **Platform foundations** | <ul><li>[5](#s5) Policy auto-onboard</li><li>[6](#s6) Cross-workspace KQL</li><li>[24](#s24) Custom Logs Ingestion API</li><li>[26](#s26) KQL Functions</li><li>[51](#s51) Platform logs at scale (DCR)</li></ul> |
 
 > **Suggested 25-min "by-workload" demos:** App Service → 3, 22, 28, 29, 33 · AKS → 4, 14, 30, 31 · Cost → 9, 11, 20, 39, 42 · Security → 27, 47, 48 · Workload health → 1 + 45 + 46.
@@ -2690,25 +2690,25 @@ Repeated alert firings should enrich one active investigation instead of produci
 ---
 
 <a id="s59"></a>
-## 59 · Evidence-backed post-incident review
+## 59 · Automatic incident command brief
 
 **Audience:** incident commanders, SRE leads, service owners.
-**Time:** 4 min.
+**Time:** 3 min.
 
 ### Story
-Recovery ends the outage, but it does not finish the learning. The agent turns the completed investigation thread into a post-incident review grounded in the evidence already collected, then exposes the weakest conclusion instead of presenting every inference as fact.
+An incident commander should not need to interrogate the agent before the first useful update appears. The response plan automatically invokes the selected specialist, and the specialist's output contract turns its investigation into a consistent brief with status, impact, evidence, confidence, and the next safe action.
 
 ### Click-path / commands
 
-1. Continue in the recovered incident thread from Scenario 58.
-2. Ask: `Create a post-incident review from this thread. Include impact, detection, a timestamped timeline, root cause and confidence, contributing factors, mitigation, recovery evidence, unresolved questions, and three prioritized follow-up actions. Cite evidence for each conclusion and label inference.`
-3. Compare its timeline with the Azure Monitor alert history, Activity Log operations, Application Insights failure window, and the break and restore annotations.
-4. Ask: `Which conclusion has the weakest evidence, and what additional telemetry would most increase confidence?`
-5. Ask: `Create a six-bullet handoff for the next on-call engineer covering current status, impact, likely cause, mitigation, recovery verification, and the next action.`
-6. Treat the result as a review draft. Confirm owners and due dates outside the agent before using the follow-up actions as commitments.
+1. Open either investigation created by the response plans in Scenario 55 or 56. Do not enter a prompt.
+2. Show the **Incident command brief** produced automatically by the selected custom investigator.
+3. Confirm that the brief contains the current status, customer or workload impact, affected resources, first signal, likely cause with confidence, timestamped evidence, the smallest safe next action, and missing evidence.
+4. Show that the application route cites Application Insights and App Service evidence, while the platform route cites AKS, VM, or Resource Health evidence.
+5. Compare the initial brief with the recovery evidence collected in Scenario 58, highlighting the difference between the first hypothesis and verified recovery.
+6. Point out that Review mode still requires approval for resource changes even though investigation and incident communication begin automatically.
 
 ### Killer line
-> *"The same evidence that drove recovery becomes a review-ready timeline, and the agent shows where confidence ends instead of polishing uncertainty into fact."*
+> *"Nobody had to ask the first question. The alert selected the specialist, the specialist built the evidence chain, and the incident commander opened a ready-to-use brief."*
 
 **Reference:** [Stage SRE Agent](STAGE-SRE-AGENT.md)
 

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -25,7 +25,7 @@ Pick a workload (or theme) and run only those scenarios. Each row links to the n
 | **Security** | <ul><li>[27](#s27) Granular RBAC</li><li>[43](#s43) Sentinel</li><li>[44](#s44) Search jobs + Restore</li><li>[47](#s47) Control-plane drift watch</li><li>[48](#s48) Privilege escalation watch</li><li>[49](#s49) Exfil early warning</li></ul> |
 | **AI / ML in Azure Monitor** | <ul><li>[16](#s16) Copilot</li><li>[13](#s13) Smart Detection</li><li>[17](#s17) Dynamic Thresholds</li><li>[18](#s18) Code Optimizations</li><li>[19](#s19) Predictive autoscale</li></ul> |
 | **GenAI observability (optional AI stage)** | <ul><li>[53](#s53) AI FinOps — token / trace / cost</li></ul> |
-| **Azure SRE Agent (optional trial)** | <ul><li>[54](#s54) Trial readiness</li><li>[55](#s55) Alert-driven App Service investigation</li><li>[56](#s56) AKS crash-loop diagnosis</li><li>[57](#s57) Change correlation</li><li>[58](#s58) Alert merging and verified recovery</li></ul> |
+| **Azure SRE Agent (optional trial)** | <ul><li>[54](#s54) Trial readiness</li><li>[55](#s55) Alert-driven App Service investigation</li><li>[56](#s56) AKS crash-loop diagnosis</li><li>[57](#s57) Change correlation</li><li>[58](#s58) Alert merging and verified recovery</li><li>[59](#s59) Evidence-backed post-incident review</li></ul> |
 | **Platform foundations** | <ul><li>[5](#s5) Policy auto-onboard</li><li>[6](#s6) Cross-workspace KQL</li><li>[24](#s24) Custom Logs Ingestion API</li><li>[26](#s26) KQL Functions</li><li>[51](#s51) Platform logs at scale (DCR)</li></ul> |
 
 > **Suggested 25-min "by-workload" demos:** App Service → 3, 22, 28, 29, 33 · AKS → 4, 14, 30, 31 · Cost → 9, 11, 20, 39, 42 · Security → 27, 47, 48 · Workload health → 1 + 45 + 46.
@@ -2689,6 +2689,31 @@ Repeated alert firings should enrich one active investigation instead of produci
 
 ---
 
+<a id="s59"></a>
+## 59 · Evidence-backed post-incident review
+
+**Audience:** incident commanders, SRE leads, service owners.
+**Time:** 4 min.
+
+### Story
+Recovery ends the outage, but it does not finish the learning. The agent turns the completed investigation thread into a post-incident review grounded in the evidence already collected, then exposes the weakest conclusion instead of presenting every inference as fact.
+
+### Click-path / commands
+
+1. Continue in the recovered incident thread from Scenario 58.
+2. Ask: `Create a post-incident review from this thread. Include impact, detection, a timestamped timeline, root cause and confidence, contributing factors, mitigation, recovery evidence, unresolved questions, and three prioritized follow-up actions. Cite evidence for each conclusion and label inference.`
+3. Compare its timeline with the Azure Monitor alert history, Activity Log operations, Application Insights failure window, and the break and restore annotations.
+4. Ask: `Which conclusion has the weakest evidence, and what additional telemetry would most increase confidence?`
+5. Ask: `Create a six-bullet handoff for the next on-call engineer covering current status, impact, likely cause, mitigation, recovery verification, and the next action.`
+6. Treat the result as a review draft. Confirm owners and due dates outside the agent before using the follow-up actions as commitments.
+
+### Killer line
+> *"The same evidence that drove recovery becomes a review-ready timeline, and the agent shows where confidence ends instead of polishing uncertainty into fact."*
+
+**Reference:** [Stage SRE Agent](STAGE-SRE-AGENT.md)
+
+---
+
 ## Updated demo flow (≈50 min)
 
 | Min | Scenario |
@@ -2730,7 +2755,7 @@ Repeated alert firings should enrich one active investigation instead of produci
 | **SecOps** | 27 → 47 → 48 → 49 → 44 |
 | **AI/ML curious** | 16 → 13 → 17 → 18 → 19 → 53 |
 | **Workload owners / SRE leads** | 1 → 45 → 12 → 7 → 8 (Root entity flips Unhealthy) |
-| **SRE Agent evaluation** | 54 → 55 → 56 → 57 → 58 |
+| **SRE Agent evaluation** | 54 → 55 → 56 → 57 → 58 → 59 |
 
 ## Reset between demos
 

--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -830,7 +830,7 @@ ML model (same engine as dynamic thresholds)
 **Time:** 3–4 min.
 
 ### Story
-Not every log table needs full KQL power. **Basic Logs** costs ~8× less per GB — with the trade-off of 8-day retention and limited KQL operators (no `join`, `summarize`, `union`). For high-volume, low-query tables like `ContainerLogV2`, it's a massive cost win.
+Not every log table needs full KQL power. **Basic Logs** costs ~8× less per GB — with the trade-off of 30-day interactive retention and limited KQL operators (no `join`, `summarize`, `union`). For high-volume, low-query tables like `ContainerLogV2`, it's a massive cost win.
 
 ### Click-path
 
@@ -842,14 +842,14 @@ Not every log table needs full KQL power. **Basic Logs** costs ~8× less per GB 
    ```
 3. Toggle to Basic:
    ```powershell
-   ./scripts/toggle-table-plan.ps1 -Plan Basic
+   ./scripts/toggle-table-plan.ps1 -ResourceGroup $resourceGroup -Plan Basic
    ```
 4. Show what changes:
    - **Works:** `ContainerLogV2 | where LogMessage has "error" | take 10`
    - **Fails:** `ContainerLogV2 | summarize count() by PodName` → error: *summarize not supported on Basic Logs*
 5. Toggle back:
    ```powershell
-   ./scripts/toggle-table-plan.ps1 -Plan Analytics
+   ./scripts/toggle-table-plan.ps1 -ResourceGroup $resourceGroup -Plan Analytics
    ```
 
 ### Key comparison
@@ -857,7 +857,7 @@ Not every log table needs full KQL power. **Basic Logs** costs ~8× less per GB 
 | | Analytics Logs | Basic Logs |
 |---|---|---|
 | **Ingestion cost** | ~$2.76/GB | ~$0.55/GB (8× cheaper) |
-| **Retention** | 30d–730d interactive | 8 days fixed |
+| **Retention** | 30d–730d interactive | 30 days interactive |
 | **KQL** | Full | where, extend, parse, project only |
 | **Alerts** | Standard log search alerts | Supported (higher per-eval cost) |
 | **Search Jobs** | N/A | Use for ad-hoc complex queries |

--- a/docs/POST-DEPLOYMENT.md
+++ b/docs/POST-DEPLOYMENT.md
@@ -113,7 +113,7 @@ The SLI helper verifies prerequisites but intentionally does not create the prev
 
 This section applies only when the optional SRE Agent stage was enabled. Infrastructure deployment creates the Sweden Central agent, identities, RBAC, and monitoring connectors. The setup script validates those resources but does not create portal-owned investigators or response plans.
 
-Before running Scenarios [55 through 58](DEMO-SCENARIOS.md#s55):
+Before running Scenarios [55 through 59](DEMO-SCENARIOS.md#s55):
 
 1. Open the deployed agent in `sre.azure.com`.
 2. Connect Azure Monitor under **Incidents > Triggers & response plans** if it is not already connected.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -165,7 +165,7 @@ Same lab, broken into 5 progressive stages so you can pause for discussion after
 | **D — Security posture** | Monitor-native detections | Granular RBAC roles · control-plane drift / privilege escalation / exfil scheduled-query alerts | 27, 47, 48, 49 | 5–12 min | €0–15 |
 | **E — Optional advanced** | SOC + reliability previews | Microsoft Sentinel onboarding · search jobs + restore · Service Group + Health Model (preview) · SLIs/SLOs · data export · Prometheus rule group | 43, 44, 45, 46 | 10–20 min | €0–40 |
 | **AI — GenAI observability** *(optional, off)* | AI FinOps on Foundry | Microsoft Foundry account + project (swedencentral) · chat/embedding/optimization/model-router deployments · App Insights tracing · token anomaly + spike alerts · AI FinOps query pack + workbook · AI health tier · agents + traffic (`setup-ai.ps1`) | 53 | 10–15 min | billable models |
-| **SRE Agent (optional, off)** | AI-assisted incident response | Bicep-deployed agent (swedencentral) · managed identity + RBAC · Azure Monitor, App Insights, and LAW connectors · two Review-mode investigators · deployment validation (`setup-sre-agent.ps1`) | 54-58 | 15-20 min | active AAUs; fixed charge waived during eligible trial |
+| **SRE Agent (optional, off)** | AI-assisted incident response | Bicep-deployed agent (swedencentral) · managed identity + RBAC · Azure Monitor, App Insights, and LAW connectors · two Review-mode investigators · deployment validation (`setup-sre-agent.ps1`) | 54-59 | 20-25 min | active AAUs; fixed charge waived during eligible trial |
 
 Walk-through docs:
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -165,7 +165,7 @@ Same lab, broken into 5 progressive stages so you can pause for discussion after
 | **D — Security posture** | Monitor-native detections | Granular RBAC roles · control-plane drift / privilege escalation / exfil scheduled-query alerts | 27, 47, 48, 49 | 5–12 min | €0–15 |
 | **E — Optional advanced** | SOC + reliability previews | Microsoft Sentinel onboarding · search jobs + restore · Service Group + Health Model (preview) · SLIs/SLOs · data export · Prometheus rule group | 43, 44, 45, 46 | 10–20 min | €0–40 |
 | **AI — GenAI observability** *(optional, off)* | AI FinOps on Foundry | Microsoft Foundry account + project (swedencentral) · chat/embedding/optimization/model-router deployments · App Insights tracing · token anomaly + spike alerts · AI FinOps query pack + workbook · AI health tier · agents + traffic (`setup-ai.ps1`) | 53 | 10–15 min | billable models |
-| **SRE Agent (optional, off)** | AI-assisted incident response | Bicep-deployed agent (swedencentral) · managed identity + RBAC · Azure Monitor, App Insights, and LAW connectors · two Review-mode investigators · deployment validation (`setup-sre-agent.ps1`) | 54-59 | 20-25 min | active AAUs; fixed charge waived during eligible trial |
+| **SRE Agent (optional, off)** | AI-assisted incident response | Bicep-deployed agent (swedencentral) · managed identity + RBAC · Azure Monitor, App Insights, and LAW connectors · two Review-mode investigators with automatic incident briefs · deployment validation (`setup-sre-agent.ps1`) | 54-59 | 20-25 min | active AAUs; fixed charge waived during eligible trial |
 
 Walk-through docs:
 

--- a/docs/STAGE-SRE-AGENT.md
+++ b/docs/STAGE-SRE-AGENT.md
@@ -159,7 +159,11 @@ Correlate evidence from 15 minutes before the first signal through 30 minutes
 after it. State the observed impact, timeline, likely cause, confidence, and the
 smallest reversible mitigation. Separate evidence from inference. Do not modify
 resources without approval. After an approved action, verify the original alert
-signal and application failure rate before declaring recovery.
+signal and application failure rate before declaring recovery. Do not wait for
+a follow-up question. End every response-plan run with an `Incident command
+brief` containing current status, customer impact, affected resources, first
+signal, likely cause and confidence, three timestamped evidence bullets with
+their sources, the smallest safe next action, and any missing evidence.
 ```
 
 ### Platform Investigator
@@ -174,7 +178,11 @@ metrics. For virtual machines, inspect power state, heartbeat, metrics, Resource
 Health, and Activity Logs. Build a timestamped evidence chain and identify the
 affected component and blast radius. Separate evidence from inference. Use
 passive diagnostics first. Ask for approval before active VM commands or any
-resource change. Verify the original signal after an approved mitigation.
+resource change. Verify the original signal after an approved mitigation. Do
+not wait for a follow-up question. End every response-plan run with an `Incident
+command brief` containing current status, workload impact, affected resources,
+first signal, likely cause and confidence, three timestamped evidence bullets
+with their sources, the smallest safe next action, and any missing evidence.
 ```
 
 ## 6. Create response plans
@@ -190,14 +198,14 @@ The portal currently accepts one **Title contains** value per plan. Use `webapp`
 
 ## 7. Run the scenarios
 
-Scenarios 54 through 59 in `DEMO-SCENARIOS.md` form one 24-minute SRE Agent flow:
+Scenarios 54 through 59 in `DEMO-SCENARIOS.md` form one 23-minute SRE Agent flow:
 
 1. Validate the trial, scope, and permissions.
 2. Trigger an App Service incident and watch automatic investigation start.
 3. Diagnose the AKS crash loop with the platform investigator.
 4. Correlate the incident with Activity Log changes and release annotations.
 5. Demonstrate repeated-alert merging, restore the lab, and verify recovery.
-6. Generate an evidence-backed post-incident review and on-call handoff.
+6. Show the incident command brief generated automatically by the response-plan investigator.
 
 ## 8. Done when
 
@@ -211,7 +219,7 @@ Scenarios 54 through 59 in `DEMO-SCENARIOS.md` form one 24-minute SRE Agent flow
 8. A fired lab alert creates or updates an investigation thread.
 9. The agent cites evidence from at least two Azure observability sources.
 10. The agent confirms recovery after `restore-the-lab.ps1`.
-11. The post-incident review separates evidence from inference and identifies its weakest conclusion.
+11. The selected investigator produces an incident command brief without waiting for a user prompt.
 
 ## 9. Stop costs
 

--- a/docs/STAGE-SRE-AGENT.md
+++ b/docs/STAGE-SRE-AGENT.md
@@ -190,13 +190,14 @@ The portal currently accepts one **Title contains** value per plan. Use `webapp`
 
 ## 7. Run the scenarios
 
-Scenarios 54 through 58 in `DEMO-SCENARIOS.md` form one 20-minute SRE Agent flow:
+Scenarios 54 through 59 in `DEMO-SCENARIOS.md` form one 24-minute SRE Agent flow:
 
 1. Validate the trial, scope, and permissions.
 2. Trigger an App Service incident and watch automatic investigation start.
 3. Diagnose the AKS crash loop with the platform investigator.
 4. Correlate the incident with Activity Log changes and release annotations.
 5. Demonstrate repeated-alert merging, restore the lab, and verify recovery.
+6. Generate an evidence-backed post-incident review and on-call handoff.
 
 ## 8. Done when
 
@@ -210,6 +211,7 @@ Scenarios 54 through 58 in `DEMO-SCENARIOS.md` form one 20-minute SRE Agent flow
 8. A fired lab alert creates or updates an investigation thread.
 9. The agent cites evidence from at least two Azure observability sources.
 10. The agent confirms recovery after `restore-the-lab.ps1`.
+11. The post-incident review separates evidence from inference and identifies its weakest conclusion.
 
 ## 9. Stop costs
 

--- a/scripts/setup-sre-agent.ps1
+++ b/scripts/setup-sre-agent.ps1
@@ -238,6 +238,6 @@ if ($GrantMissingRoles -and $missingRoles.Count -gt 0) {
 Write-Step 'Open the deployed agent'
 Write-Host "  https://sre.azure.com/#/agent/$SubscriptionId/$ResourceGroup/$($agent.name)"
 Write-Host '  The agent is configured in Review mode with Azure Monitor, Application Insights, and Log Analytics connectors.'
-Write-Host '  Add the lab response plans from docs/STAGE-SRE-AGENT.md before running scenarios 54 through 58.'
+Write-Host '  Add the lab response plans from docs/STAGE-SRE-AGENT.md before running scenarios 54 through 59.'
 Write-Host "`nTrial note: baseline always-on charges are waived for 30 days, but active Azure Agent Unit usage is billed." -ForegroundColor Yellow
 Write-Host 'See docs/STAGE-SRE-AGENT.md for the custom agent instructions, response plans, and demo flow.'

--- a/scripts/toggle-table-plan.ps1
+++ b/scripts/toggle-table-plan.ps1
@@ -7,10 +7,11 @@
   Shows the 8x cost difference and query limitations of Basic Logs.
 
 .PARAMETER ResourceGroup
-  Resource group containing the demo lab.
+  Resource group containing the demo lab. When omitted, the script prompts for it.
 
 .PARAMETER WorkspaceName
-  LAW name (default: law-amlab-central).
+  Central LAW name. When omitted, the script discovers the single workspace matching
+  law-amlab-central-* in the resource group.
 
 .PARAMETER TableName
   Table to toggle (default: ContainerLogV2).
@@ -19,8 +20,8 @@
   Target plan: 'Basic' or 'Analytics'.
 #>
 param(
-  [string]$ResourceGroup = 'rg-azure-monitor-lab',
-  [string]$WorkspaceName = 'law-amlab-central',
+  [string]$ResourceGroup,
+  [string]$WorkspaceName,
   [string]$TableName = 'ContainerLogV2',
 
   [Parameter(Mandatory)]
@@ -30,14 +31,47 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+function Assert-NativeCommandSucceeded([string]$Operation) {
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Operation failed with exit code $LASTEXITCODE."
+  }
+}
+
 Write-Host "`n=== Table Plan Toggle ===" -ForegroundColor Cyan
+
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
+  $ResourceGroup = Read-Host 'Resource group containing the demo lab'
+}
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
+  throw 'ResourceGroup is required.'
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkspaceName)) {
+  Write-Host "Discovering central Log Analytics workspace in '$ResourceGroup'..." -ForegroundColor Gray
+  $workspaces = @(az monitor log-analytics workspace list -g $ResourceGroup -o json | ConvertFrom-Json)
+  Assert-NativeCommandSucceeded "Listing Log Analytics workspaces in resource group '$ResourceGroup'"
+
+  $centralWorkspaces = @($workspaces | Where-Object { $_.name -like 'law-amlab-central-*' })
+  if ($centralWorkspaces.Count -eq 0) {
+    throw "No workspace matching 'law-amlab-central-*' was found in resource group '$ResourceGroup'. Pass -WorkspaceName explicitly if the lab uses a different name."
+  }
+  if ($centralWorkspaces.Count -gt 1) {
+    $workspaceNames = $centralWorkspaces.name -join ', '
+    throw "Multiple workspaces matching 'law-amlab-central-*' were found in resource group '$ResourceGroup': $workspaceNames. Pass -WorkspaceName explicitly."
+  }
+
+  $WorkspaceName = $centralWorkspaces[0].name
+}
 
 # Show current plan
 $current = az monitor log-analytics workspace table show `
   -g $ResourceGroup --workspace-name $WorkspaceName -n $TableName `
-  --query "properties.plan" -o tsv
+  --query "plan" -o tsv
+Assert-NativeCommandSucceeded "Reading the plan for table '$TableName'"
 
 Write-Host "Table:        $TableName" -ForegroundColor Gray
+Write-Host "Resource group: $ResourceGroup" -ForegroundColor Gray
+Write-Host "Workspace:      $WorkspaceName" -ForegroundColor Gray
 Write-Host "Current plan: $current" -ForegroundColor Yellow
 Write-Host "Target plan:  $Plan" -ForegroundColor Yellow
 
@@ -49,16 +83,36 @@ if ($current -eq $Plan) {
 # Toggle
 Write-Host "`nSwitching $TableName to '$Plan'..." -ForegroundColor Yellow
 
-if ($Plan -eq 'Basic') {
-  # Basic Logs requires workspace-default retention — reset any custom retention first
-  az monitor log-analytics workspace table update `
-    -g $ResourceGroup --workspace-name $WorkspaceName -n $TableName `
-    --retention-time -1 --total-retention-time -1 -o none 2>$null
+$subscriptionId = az account show --query id -o tsv
+Assert-NativeCommandSucceeded 'Reading the active Azure subscription'
+$tableUri = "https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.OperationalInsights/workspaces/$WorkspaceName/tables/$TableName`?api-version=2025-02-01"
+$bodyFile = New-TemporaryFile
+try {
+  @{ properties = @{ plan = $Plan } } |
+    ConvertTo-Json -Depth 3 -Compress |
+    Set-Content -Path $bodyFile -Encoding utf8
+
+  az rest --method PATCH --uri $tableUri --body "@$bodyFile" `
+    --headers 'Content-Type=application/json' --only-show-errors -o none
+  Assert-NativeCommandSucceeded "Switching table '$TableName' to the '$Plan' plan"
+} finally {
+  Remove-Item -Path $bodyFile -Force -ErrorAction SilentlyContinue
 }
 
-az monitor log-analytics workspace table update `
-  -g $ResourceGroup --workspace-name $WorkspaceName -n $TableName `
-  --plan $Plan -o none
+$updatedPlan = $null
+for ($attempt = 1; $attempt -le 12; $attempt++) {
+  $updatedPlan = az monitor log-analytics workspace table show `
+    -g $ResourceGroup --workspace-name $WorkspaceName -n $TableName `
+    --query "plan" -o tsv
+  Assert-NativeCommandSucceeded "Verifying the plan for table '$TableName'"
+  if ($updatedPlan -eq $Plan) {
+    break
+  }
+  Start-Sleep -Seconds 5
+}
+if ($updatedPlan -ne $Plan) {
+  throw "Table '$TableName' reported plan '$updatedPlan' after requesting '$Plan'."
+}
 
 Write-Host "Done. $TableName is now on the '$Plan' plan." -ForegroundColor Green
 
@@ -67,17 +121,17 @@ if ($Plan -eq 'Basic') {
 
 === Basic Logs: what changes ===
   Cost:        ~8x cheaper ingestion (per-GB rate)
-  Retention:   8 days (fixed, no interactive retention extension)
+  Retention:   30 days interactive; total retention remains unchanged
   KQL:         Limited — only: where, extend, parse, project, search
                NO: join, union, summarize, sort, distinct, count
   Search jobs: Use search jobs for complex analytics on Basic Logs data
   Alerts:      Log search alerts work (at higher cost per evaluation)
 
   Try this KQL (works on Basic):
-    SecurityAudit_CL | where Severity == "Critical" | take 10
+    $TableName | where LogMessage has "error" | take 10
 
   This KQL will FAIL on Basic:
-    SecurityAudit_CL | summarize count() by EventType
+    $TableName | summarize count() by PodName
 "@ -ForegroundColor Gray
 } else {
   Write-Host "`nFull KQL and 30-day interactive retention restored." -ForegroundColor Gray


### PR DESCRIPTION
## Summary

- add an SRE Agent post-incident review scenario and automate incident command briefs
- align SRE Agent setup and reference documentation with the updated workflow
- discover the suffixed central Log Analytics workspace from the selected resource group
- harden the Basic/Analytics table-plan toggle with plan-only REST updates, native error handling, and read-back verification
- update the Basic Logs demo for current 30-day interactive retention behavior

## Validation

- PowerShell parser check passed for scripts/toggle-table-plan.ps1
- mocked success and Azure CLI failure handling paths passed
- live plan update verified ContainerLogV2 as Basic with provisioningState Succeeded
- branch is clean and synchronized with origin