### PR TITLE
Add standalone LAW replication command

### DIFF
--- a/docs/DEMO-SCENARIOS.md
+++ b/docs/DEMO-SCENARIOS.md
@@ -1729,13 +1729,15 @@ The App Service has **three** diagnostic settings stacked on it — same source 
 ---
 
 <a id="s41"></a>
-## 41 · Cost — LAW cross-region replication (BCDR knob)
+## 41 · Cost: LAW cross-region replication (BCDR knob)
 
 **Audience:** BCDR architects, regulated industries.
-**Time:** 2 min — fact-check + click-path.
+**Time:** 2 min: fact-check + click-path.
 
 ### Story
-LAW now supports **active-active workspace replication** — the workspace is synchronously copied into a second region, query/ingest endpoints continue to work if either region is down. **Off by default in this lab** (it doubles ingest cost) but the Bicep param is wired and ready.
+LAW workspace replication creates a secondary shadow instance in another supported region. New logs are copied to it, but switching ingestion and queries to that region is a manual operation. **Off by default in this lab** because replication adds a charge for all billable ingested data. The Bicep parameter and a focused command for existing workspaces are both available.
+
+Source: [Enhance resilience by replicating your Log Analytics workspace across regions](https://learn.microsoft.com/azure/azure-monitor/logs/workspace-replication?tabs=azure-cli#enable-workspace-replication).
 
 ### What's wired
 
@@ -1752,23 +1754,31 @@ When `enableReplication = true`, the property `replication: { enabled: true, loc
 
 1. Show current state (replication off):
    ```powershell
-   az resource show -g rg-azure-monitor-lab `
-     --resource-type Microsoft.OperationalInsights/workspaces -n law-amlab-central `
-     --query "properties.replication"
+    $workspaceName = az monitor log-analytics workspace list `
+       --resource-group $resourceGroup `
+       --query "[?starts_with(name, 'law-amlab-central-')].name | [0]" -o tsv
+
+    az monitor log-analytics workspace show `
+       --resource-group $resourceGroup `
+       --workspace-name $workspaceName `
+       --query "replication"
    ```
 2. Enable for the demo:
    ```powershell
-   az deployment group create -g rg-azure-monitor-lab `
-     --template-file infra/main.bicep `
-     --parameters @infra/main.parameters.json `
-                  enableLawReplication=true `
-                  lawReplicationLocation=westeurope
+   ./scripts/enable-law-replication.ps1 `
+     -SubscriptionId $subscriptionId `
+     -ResourceGroup $resourceGroup `
+     -ReplicationLocation westeurope
    ```
-3. **`law-amlab-central` → Overview** → wait ~15 min → the *Replication* tile flips to **Active** with a second region listed.
-4. Failover query (set workspace context to the secondary): same KQL, no change.
+   This uses the documented `az rest --method put` request with API `2025-02-01` and updates only the existing central workspace. Historical logs remain in the primary workspace, but only new logs ingested after replication becomes active are copied to the secondary region.
+3. **`law-amlab-central-*` → Overview** → wait for the *Replication* tile to become **Active** with the second region listed. Individual data types can take up to one hour to begin replicating.
+4. Before demonstrating switchover, associate eligible DCRs with the workspace system DCE and confirm each DCR targets only this workspace. This is required for DCR-based ingestion continuity.
+5. Trigger switchover explicitly when the secondary contains enough useful data. Microsoft recommends waiting at least one week after enablement before relying on it for a planned switchover.
+
+> **Compatibility note:** The cited Microsoft Learn page currently lists Container Insights, VM Insights, and Application Insights over Log Analytics workspaces as unsupported for replication and switchover. Do not present those lab paths as protected by this feature.
 
 ### Killer line
-> *"Two regions, one workspace, one KQL surface — and a single Bicep parameter to turn it on the day you need it."*
+> *"Two regions, one workspace, one KQL surface, and one focused command to turn it on for an existing environment."*
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,6 +44,7 @@ For a fresh deployment, use `deploy.ps1` rather than calling `post-deploy.ps1` d
 | `setup-grafana-alerts.ps1` | Creates the Grafana alert rule for the Managed Prometheus data source. | `./scripts/setup-grafana-alerts.ps1 -ResourceGroup <rg>` |
 | `create-summary-rule.ps1` | Creates or updates the hourly `Perf_Hourly_CL` summary rule. It discovers the suffixed central LAW when `-WorkspaceName` is omitted. | `./scripts/create-summary-rule.ps1 -ResourceGroup <rg>` |
 | `toggle-table-plan.ps1` | Switches a Log Analytics table between `Basic` and `Analytics` plans. | `./scripts/toggle-table-plan.ps1 -ResourceGroup <rg> -TableName ContainerLogV2 -Plan Basic` |
+| `enable-law-replication.ps1` | Enables cross-region replication on the existing suffixed central LAW without redeploying the lab. Uses the documented API `2025-02-01` workspace PUT operation. | `./scripts/enable-law-replication.ps1 -SubscriptionId <sub> -ResourceGroup <rg> -ReplicationLocation westeurope` |
 | `run-search-job.ps1` | Runs a Log Analytics search job over archived or Basic Logs data. | `./scripts/run-search-job.ps1 -ResourceGroup <rg> -TableName ContainerLogV2` |
 | `restore-archived-logs.ps1` | Restores selected archived data for querying. | `./scripts/restore-archived-logs.ps1 -ResourceGroup <rg> -TableName ContainerLogV2 -LookbackDays 14` |
 

--- a/scripts/enable-law-replication.ps1
+++ b/scripts/enable-law-replication.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+  Enables cross-region replication on an existing central Log Analytics workspace.
+
+.DESCRIPTION
+  Discovers the single law-amlab-central-* workspace in the resource group and
+  enables replication without redeploying the lab. Existing logs remain in the
+  primary workspace; only logs ingested after activation replicate to the secondary.
+
+.PARAMETER SubscriptionId
+  Expected Azure subscription ID. The script pins and verifies this subscription.
+
+.PARAMETER ResourceGroup
+  Resource group containing the demo lab.
+
+.PARAMETER ReplicationLocation
+  Supported secondary Azure region, such as westeurope.
+
+.PARAMETER WorkspaceName
+  Optional explicit workspace name. When omitted, discovers law-amlab-central-*.
+
+.LINK
+  https://learn.microsoft.com/azure/azure-monitor/logs/workspace-replication?tabs=azure-cli#enable-workspace-replication
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)] [string] $SubscriptionId,
+  [Parameter(Mandatory)] [string] $ResourceGroup,
+  [Parameter(Mandatory)] [string] $ReplicationLocation,
+  [string] $WorkspaceName
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-NativeCommandSucceeded([string] $Operation) {
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Operation failed with exit code $LASTEXITCODE."
+  }
+}
+
+Write-Host "`n=== Log Analytics Workspace Replication ===" -ForegroundColor Cyan
+
+$targetFile = Join-Path $PSScriptRoot '..' '.azure-target.json'
+$target = if (Test-Path $targetFile) {
+  Get-Content -Raw $targetFile | ConvertFrom-Json
+} else {
+  $null
+}
+if ($target -and $SubscriptionId -ne $target.expectedSubscriptionId) {
+  throw "BLOCKED: -SubscriptionId '$SubscriptionId' does not match .azure-target.json '$($target.expectedSubscriptionId)'."
+}
+if ($target -and $target.forbiddenSubscriptionIds -contains $SubscriptionId) {
+  throw "BLOCKED: subscription '$SubscriptionId' is listed as forbidden in .azure-target.json."
+}
+
+az account set --subscription $SubscriptionId | Out-Null
+Assert-NativeCommandSucceeded 'Setting the Azure subscription'
+$activeAccount = az account show --query '{id:id,tenantId:tenantId}' -o json | ConvertFrom-Json
+Assert-NativeCommandSucceeded 'Reading the active Azure subscription'
+if ($activeAccount.id -ne $SubscriptionId) {
+  throw "BLOCKED: active subscription '$($activeAccount.id)' does not match expected subscription '$SubscriptionId'."
+}
+if ($target -and $activeAccount.tenantId -ne $target.expectedTenantId) {
+  throw "BLOCKED: active tenant '$($activeAccount.tenantId)' does not match .azure-target.json '$($target.expectedTenantId)'."
+}
+
+if ([string]::IsNullOrWhiteSpace($WorkspaceName)) {
+  $workspaces = @(az monitor log-analytics workspace list -g $ResourceGroup -o json | ConvertFrom-Json)
+  Assert-NativeCommandSucceeded "Listing Log Analytics workspaces in resource group '$ResourceGroup'"
+  $centralWorkspaces = @($workspaces | Where-Object { $_.name -like 'law-amlab-central-*' })
+
+  if ($centralWorkspaces.Count -eq 0) {
+    throw "No workspace matching 'law-amlab-central-*' was found in resource group '$ResourceGroup'."
+  }
+  if ($centralWorkspaces.Count -gt 1) {
+    throw "Multiple central workspaces were found: $($centralWorkspaces.name -join ', '). Pass -WorkspaceName explicitly."
+  }
+  $WorkspaceName = $centralWorkspaces[0].name
+}
+
+$workspace = az monitor log-analytics workspace show `
+  -g $ResourceGroup -n $WorkspaceName -o json | ConvertFrom-Json
+Assert-NativeCommandSucceeded "Reading Log Analytics workspace '$WorkspaceName'"
+
+if ($workspace.replication.enabled -eq $true) {
+  if ($workspace.replication.location -ieq $ReplicationLocation) {
+    Write-Host "Replication is already enabled to '$ReplicationLocation'. No change needed." -ForegroundColor Green
+    return
+  }
+  throw "Replication is already enabled to '$($workspace.replication.location)'. Disable it and wait for completion before selecting another location."
+}
+if ($workspace.location -ieq $ReplicationLocation) {
+  throw "Replication location '$ReplicationLocation' must differ from the primary location '$($workspace.location)'."
+}
+
+$workspaceUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.OperationalInsights/workspaces/$WorkspaceName`?api-version=2025-02-01"
+$bodyFile = New-TemporaryFile
+try {
+  @{
+    location = $workspace.location
+    properties = @{
+      replication = @{
+        enabled = $true
+        location = $ReplicationLocation
+      }
+    }
+  } | ConvertTo-Json -Depth 4 | Set-Content -Path $bodyFile -Encoding utf8
+
+  Write-Host "Workspace:          $WorkspaceName" -ForegroundColor Gray
+  Write-Host "Primary location:   $($workspace.location)" -ForegroundColor Gray
+  Write-Host "Secondary location: $ReplicationLocation" -ForegroundColor Gray
+  Write-Host 'Enabling replication...' -ForegroundColor Yellow
+
+  az rest --method PUT --uri $workspaceUri --body "@$bodyFile" `
+    --headers 'Content-Type=application/json' --only-show-errors -o none
+  Assert-NativeCommandSucceeded "Enabling replication on workspace '$WorkspaceName'"
+} finally {
+  Remove-Item -Path $bodyFile -Force -ErrorAction SilentlyContinue
+}
+
+$replication = az monitor log-analytics workspace show `
+  -g $ResourceGroup -n $WorkspaceName `
+  --query "replication.{enabled:enabled,location:location,provisioningState:provisioningState}" -o json |
+  ConvertFrom-Json
+Assert-NativeCommandSucceeded "Reading replication state for workspace '$WorkspaceName'"
+
+Write-Host "Replication request accepted: enabled=$($replication.enabled), location=$($replication.location), state=$($replication.provisioningState)" -ForegroundColor Green
+Write-Host 'Provisioning can take several minutes, and data types can take up to one hour to begin replicating.' -ForegroundColor Yellow
+Write-Host 'Only logs ingested after replication becomes active are copied to the secondary region.' -ForegroundColor Yellow
+Write-Host 'DCR-based ingestion requires each DCR to use this workspace system DCE for switchover continuity.' -ForegroundColor Yellow
+Write-Host 'Review unsupported and partially supported features before relying on switchover.' -ForegroundColor Yellow


### PR DESCRIPTION
Uses the Microsoft Learn documented az rest workspace PUT with API 2025-02-01; avoids full Bicep redeployment for an existing workspace; pins/verifies subscription and tenant; documents no historical backfill, paid replication, manual switchover, DCR/system-DCE requirement, and unsupported Insights integrations; validation was PowerShell parser plus git diff --check; no live replication was enabled because it is billable.