### PR TITLE
Deploy security posture alerts in one-shot path

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -679,6 +679,19 @@ module lawRbac 'modules/law-rbac.bicep' = {
   }
 }
 
+// ---------------------------------------------------------------------------------
+// FEATURE 12 — Security posture alerts (control-plane drift, privilege, exfiltration)
+// ---------------------------------------------------------------------------------
+module securityPostureAlerts 'modules/security-posture-alerts.bicep' = {
+  name: 'security-posture-alerts'
+  params: {
+    location: location
+    workspaceId: lawCentral.outputs.id
+    actionGroupId: actionGroup.outputs.id
+    tags: commonTags
+  }
+}
+
 // =================================================================================
 // NEW FEATURES — Network observability, Sentinel, Prom rules, Cost workbook, etc.
 // =================================================================================


### PR DESCRIPTION
## Summary

- wire the existing security posture alert module into the one-shot Bicep deployment
- create the control-plane drift, privilege escalation, and exfiltration early-warning scheduled-query alerts
- route all three alerts through the existing lab Action Group

## Validation

- az bicep build --file infra/main.bicep
- git diff --check

## Expected deployment effect

The next one-shot deployment creates:

- alert-security-control-plane-drift
- alert-security-privilege-escalation-watch
- alert-security-exfil-early-warning